### PR TITLE
Release of v2.0.6

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,13 @@
+{
+  "name": "volverjs-query-vue",
+  "owner": {
+    "name": "8 Wave S.r.l."
+  },
+  "plugins": [
+    {
+      "name": "volverjs-query-vue",
+      "source": "./",
+      "description": "Helps agents build Vue 3 data fetching and mutations with @volverjs/query-vue (a Pinia store over the repository pattern with caching and a normalized item cache)."
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "volverjs-query-vue",
+  "description": "Helps agents build Vue 3 data fetching and mutations with @volverjs/query-vue (a Pinia store over the repository pattern with caching and a normalized item cache).",
+  "author": {
+    "name": "8 Wave S.r.l."
+  },
+  "homepage": "https://github.com/volverjs/query-vue",
+  "repository": "https://github.com/volverjs/query-vue",
+  "license": "MIT",
+  "keywords": ["vue", "pinia", "repository", "query", "data-fetching"]
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,12 @@ name: Build library
 
 on:
     workflow_call:
+        inputs:
+            release-tag:
+                description: 'Release tag name used to bump the package version (skipped when empty)'
+                required: false
+                default: ''
+                type: string
 
 jobs:
     build:
@@ -11,10 +17,10 @@ jobs:
 
             - uses: pnpm/action-setup@v4
 
-            - name: Use Node.js ${{ matrix.node-version }}
+            - name: Use Node.js 24
               uses: actions/setup-node@v4
               with:
-                  node-version: ${{ matrix.node-version }}
+                  node-version: 24
                   cache: 'pnpm'
 
             - name: Install dependencies
@@ -24,11 +30,14 @@ jobs:
               run: pnpm build
 
             - name: Bump version with release tag name
-              run: pnpm version --no-git-tag-version ${{ github.event.release.tag_name }}
+              if: inputs.release-tag != ''
+              env:
+                  RELEASE_TAG: ${{ inputs.release-tag }}
+              run: pnpm version --no-git-tag-version "${RELEASE_TAG#v}"
 
             - name: Pack package
               run: pnpm pack
-              
+
             - name: Upload artifact
               uses: actions/upload-artifact@v4
               with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,9 @@ on:
     release:
         types: [published]
 
+permissions:
+    contents: read
+
 jobs:
     analysis:
         uses: ./.github/workflows/sonarcloud.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,8 @@ jobs:
 
     build:
         uses: ./.github/workflows/build.yml
+        with:
+            release-tag: ${{ github.event.release.tag_name }}
 
     test:
         needs: build
@@ -27,7 +29,7 @@ jobs:
                   name: package
             - uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 24
                   registry-url: https://registry.npmjs.org/
             - run: npm publish $(ls *.tgz) --access=public --tag ${{ github.event.release.prerelease && 'next' || 'latest'}}
               env:
@@ -47,7 +49,7 @@ jobs:
 
             - uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 24
                   registry-url: https://npm.pkg.github.com/
                   
             - run: npm publish $(ls *.tgz) --access=public --tag ${{ github.event.release.prerelease && 'next' || 'latest'}}

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -9,20 +9,20 @@ permissions: {}
 jobs:
     build:
         permissions:
-            contents: write # to create release (yyx990803/release-tag)
+            contents: write # to create release via gh CLI
 
         name: Create Release
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@master
-              
+              uses: actions/checkout@v5
+
             - name: Create Release for Tag
-              id: release_tag
-              uses: yyx990803/release-tag@master
               env:
-                  GITHUB_TOKEN: ${{ secrets.RELEASE_TAG_GITHUB_TOKEN }}
-              with:
-                  tag_name: ${{ github.ref }}
-                  body: |
-                      Please refer to [CHANGELOG.md](https://github.com/volverjs/query-vue/blob/${{ contains(github.ref, 'beta') && 'develop' || 'main'}}/CHANGELOG.md) for details.
+                  GH_TOKEN: ${{ secrets.RELEASE_TAG_GITHUB_TOKEN }}
+              run: |
+                  gh release create "${{ github.ref_name }}" \
+                    --repo "${{ github.repository }}" \
+                    --title "${{ github.ref_name }}" \
+                    --prerelease="${{ contains(github.ref, 'beta') }}" \
+                    --notes "Please refer to [CHANGELOG.md](https://github.com/volverjs/query-vue/blob/${{ contains(github.ref, 'beta') && 'develop' || 'main' }}/CHANGELOG.md) for details."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,16 +10,12 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
-            - uses: actions/setup-node@v4
-              with:
-                  node-version: 20
-
             - uses: pnpm/action-setup@v4
 
-            - name: Use Node.js ${{ matrix.node-version }}
+            - name: Use Node.js 24
               uses: actions/setup-node@v4
               with:
-                  node-version: ${{ matrix.node-version }}
+                  node-version: 24
                   cache: 'pnpm'
 
             - name: Install dependencies
@@ -27,6 +23,6 @@ jobs:
 
             - name: Build release
               run: pnpm build
-              
+
             - name: Run Vitest test
               run: pnpm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.0.6] - 2026-06-16
+
+### Added
+
+- `keepAlive` option for the `remove()` action, consistent with `read()` and `submit()`;
+- `volverjs-query-vue` Claude Code plugin / agent skill (under `skills/`) that teaches AI coding agents how to use the library; installable with `/plugin marketplace add volverjs/query-vue`.
+
+### Changed
+
+- `submit()` `action` option is now restricted to `'create' | 'update'` (the only meaningful write operations);
+- `submit().data` and the `remove()` action `errors` are now always arrays (empty instead of `undefined`), consistent with `read()`.
+
+### Fix
+
+- Portable type declarations: the emitted `.d.ts` referenced `@vue/shared` through a non-portable `.pnpm/…` path (TS2883), which broke type-checking for consumers; it now emits a bare `@vue/shared` specifier;
+- `submit()` derived query names from `Date.now()`, so two submissions in the same millisecond could collide and overwrite each other's state; query names are now random;
+- `submit()` could throw and flip to an error state on an empty response because `clone()` failed on `undefined`; `clone()` now returns `undefined`/`null` untouched;
+- `cleanUpEvery` could not be disabled because of the default fallback; passing `0` or `false` now disables the automatic idle clean up;
+- `cleanUp()` never evicted items from the normalized cache, so it could grow unbounded; items no longer referenced by any hash are now removed.
+
 # [2.0.5] - 2026-03-26
 
 ### Fix

--- a/README.md
+++ b/README.md
@@ -695,7 +695,7 @@ const {
     isSuccess
     // ...
 } = remove(
-    /* The parameters map (required) */
+    /* The parameters map (default: undefined) */
     params,
     /* The options object (default: undefined) */
     {

--- a/README.md
+++ b/README.md
@@ -72,6 +72,56 @@ export const useUsersStore = defineStoreRepository(
 
 In a component you can use the `useUsersStore()` composable to get store actions and getters.
 
+### Store options
+
+`defineStoreRepository()` accepts an optional third argument to configure the store defaults:
+
+```ts
+export const useUsersStore = defineStoreRepository(
+    usersRepository,
+    'users',
+    {
+        /*
+         * The property (or getter) used to uniquely identify an item.
+         * Can be a key of the item, a function or an object with a `name`
+         * and a `get` function (default: 'id').
+         * For example:
+         * `keyProperty: 'uuid'`
+         * `keyProperty: (item) => item.uuid`
+         * `keyProperty: { name: 'uuid', get: (item) => item.uuid }`
+         */
+        keyProperty: 'id',
+        /*
+         * Default cache time (in milliseconds) for every query,
+         * can be overridden per `read()` with the `persistence` option
+         * (default: 60 * 60 * 1000)
+         */
+        defaultPersistence: 60 * 60 * 1000,
+        /*
+         * Default auto execute debounce (in milliseconds) for every query,
+         * can be overridden per action with the `autoExecuteDebounce` option
+         * (default: 0)
+         */
+        defaultDebounce: 0,
+        /*
+         * Parameters merged into every request (default: {})
+         */
+        defaultParameters: {},
+        /*
+         * The function used to hash the request parameters
+         * (default: Hash.cyrb53 from `@volverjs/data`)
+         */
+        hashFunction: undefined,
+        /*
+         * Interval (in milliseconds) used to schedule the store clean up
+         * on idle. Pass `0` or `false` to disable the automatic clean up
+         * (default: 3 * 1000)
+         */
+        cleanUpEvery: 3 * 1000,
+    }
+)
+```
+
 ## Read
 
 `read()` action allow to read data from the repository:
@@ -654,6 +704,11 @@ const {
          * if not defined, the query name will be generated
          */
         name: undefined,
+        /*
+         * Keep the query alive when
+         * the component is unmounted (default: false)
+         */
+        keepAlive: false,
         /* Execute the `remove()` action immediately (default: true) */
         immediate: true,
         /*

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,5 +22,8 @@ export default antfu({
         'sort-imports': 'off',
     },
 }, {
-    ignores: ['.vscode', 'dist', 'node_modules'],
+    // `skills` and `.claude-plugin` ship the agent skill / Claude Code plugin:
+    // docs and manifests for end users, not library source, so the library's
+    // own style rules (4-space indent, etc.) should not apply to them.
+    ignores: ['.vscode', 'dist', 'node_modules', 'skills', '.claude-plugin'],
 })

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
         "vue": "^3.5.x"
     },
     "devDependencies": {
-        "@antfu/eslint-config": "^7.7.3",
+        "@antfu/eslint-config": "^8.0.0",
         "@nabla/vite-plugin-eslint": "^3.0.1",
         "@pinia/testing": "^1.0.3",
         "@types/node": "^25.5.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
         "eslint": "^10.1.0",
         "happy-dom": "^20.8.8",
         "pinia": "^3.0.4",
-        "typescript": "6.0.2",
+        "typescript": "6.0.3",
         "unplugin-dts": "1.0.0-beta.6",
         "vite": "^8.0.3",
         "vitest": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
         "happy-dom": "^20.8.8",
         "pinia": "^3.0.4",
         "typescript": "6.0.3",
-        "unplugin-dts": "1.0.0-beta.6",
+        "unplugin-dts": "1.0.0",
         "vite": "^8.0.3",
         "vitest": "^4.1.1",
         "vitest-fetch-mock": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
         "vue": "^3.5.x"
     },
     "devDependencies": {
-        "@antfu/eslint-config": "^8.0.0",
+        "@antfu/eslint-config": "^9.0.0",
         "@nabla/vite-plugin-eslint": "^3.0.1",
         "@pinia/testing": "^1.0.3",
         "@types/node": "^25.5.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
         "happy-dom": "^20.8.8",
         "pinia": "^3.0.4",
         "typescript": "6.0.3",
-        "unplugin-dts": "1.0.1",
+        "unplugin-dts": "1.0.2",
         "vite": "^8.0.3",
         "vitest": "^4.1.1",
         "vitest-fetch-mock": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@volverjs/query-vue",
     "type": "module",
     "version": "0.0.0",
-    "packageManager": "pnpm@10.33.0",
+    "packageManager": "pnpm@11.7.0",
     "description": "Repository pattern applied to a pinia store.",
     "author": "8 Wave S.r.l.",
     "license": "MIT",
@@ -63,30 +63,26 @@
         "vue": "^3.5.x"
     },
     "devDependencies": {
-        "@antfu/eslint-config": "^7.7.3",
+        "@antfu/eslint-config": "^9.0.0",
         "@nabla/vite-plugin-eslint": "^3.0.1",
         "@pinia/testing": "^1.0.3",
-        "@types/node": "^25.5.0",
-        "@vitejs/plugin-vue": "^6.0.5",
-        "@volverjs/data": "^2.0.4",
-        "@vue/language-core": "^3.2.6",
-        "@vue/test-utils": "^2.4.6",
-        "@vueuse/core": "^14.2.1",
+        "@types/node": "^25.9.3",
+        "@vitejs/plugin-vue": "^6.0.7",
+        "@volverjs/data": "^2.0.5",
+        "@vue/language-core": "^3.3.5",
+        "@vue/shared": "^3.5.38",
+        "@vue/test-utils": "^2.4.11",
+        "@vueuse/core": "^14.3.0",
         "copy": "^0.3.2",
-        "eslint": "^10.1.0",
-        "happy-dom": "^20.8.8",
+        "eslint": "^10.5.0",
+        "happy-dom": "^20.10.4",
         "pinia": "^3.0.4",
-        "typescript": "6.0.2",
-        "unplugin-dts": "1.0.0-beta.6",
-        "vite": "^8.0.3",
-        "vitest": "^4.1.1",
+        "typescript": "6.0.3",
+        "unplugin-dts": "1.0.2",
+        "vite": "^8.0.16",
+        "vitest": "^4.1.9",
         "vitest-fetch-mock": "^0.4.5",
-        "vue": "^3.5.31",
-        "vue-tsc": "^3.2.6"
-    },
-    "pnpm": {
-        "onlyBuiltDependencies": [
-            "esbuild"
-        ]
+        "vue": "^3.5.38",
+        "vue-tsc": "^3.3.5"
     }
 }

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
         "happy-dom": "^20.8.8",
         "pinia": "^3.0.4",
         "typescript": "6.0.3",
-        "unplugin-dts": "1.0.0",
+        "unplugin-dts": "1.0.1",
         "vite": "^8.0.3",
         "vitest": "^4.1.1",
         "vitest-fetch-mock": "^0.4.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,76 +9,79 @@ importers:
   .:
     devDependencies:
       '@antfu/eslint-config':
-        specifier: ^7.7.3
-        version: 7.7.3(@typescript-eslint/rule-tester@8.57.2(eslint@10.1.0)(typescript@6.0.2))(@typescript-eslint/typescript-estree@8.57.2(typescript@6.0.2))(@typescript-eslint/utils@8.57.2(eslint@10.1.0)(typescript@6.0.2))(@vue/compiler-sfc@3.5.31)(eslint@10.1.0)(typescript@6.0.2)(vitest@4.1.1(@types/node@25.5.0)(happy-dom@20.8.8)(vite@8.0.3(@types/node@25.5.0)(yaml@2.8.3)))
+        specifier: ^9.0.0
+        version: 9.0.0(@typescript-eslint/rule-tester@8.57.2(eslint@10.5.0)(typescript@6.0.3))(@typescript-eslint/typescript-estree@8.61.0(typescript@6.0.3))(@typescript-eslint/utils@8.61.0(eslint@10.5.0)(typescript@6.0.3))(@vue/compiler-sfc@3.5.38)(eslint@10.5.0)(ts-declaration-location@1.0.7(typescript@6.0.3))(typescript@6.0.3)(vitest@4.1.9(@types/node@25.9.3)(happy-dom@20.10.4)(vite@8.0.16(@types/node@25.9.3)(yaml@2.8.3)))
       '@nabla/vite-plugin-eslint':
         specifier: ^3.0.1
-        version: 3.0.1(eslint@10.1.0)(vite@8.0.3(@types/node@25.5.0)(yaml@2.8.3))
+        version: 3.0.1(eslint@10.5.0)(vite@8.0.16(@types/node@25.9.3)(yaml@2.8.3))
       '@pinia/testing':
         specifier: ^1.0.3
-        version: 1.0.3(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))
+        version: 1.0.3(pinia@3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3)))
       '@types/node':
-        specifier: ^25.5.0
-        version: 25.5.0
+        specifier: ^25.9.3
+        version: 25.9.3
       '@vitejs/plugin-vue':
-        specifier: ^6.0.5
-        version: 6.0.5(vite@8.0.3(@types/node@25.5.0)(yaml@2.8.3))(vue@3.5.31(typescript@6.0.2))
+        specifier: ^6.0.7
+        version: 6.0.7(vite@8.0.16(@types/node@25.9.3)(yaml@2.8.3))(vue@3.5.38(typescript@6.0.3))
       '@volverjs/data':
-        specifier: ^2.0.4
-        version: 2.0.4(typescript@6.0.2)
+        specifier: ^2.0.5
+        version: 2.0.5(typescript@6.0.3)
       '@vue/language-core':
-        specifier: ^3.2.6
-        version: 3.2.6
+        specifier: ^3.3.5
+        version: 3.3.5
+      '@vue/shared':
+        specifier: ^3.5.38
+        version: 3.5.38
       '@vue/test-utils':
-        specifier: ^2.4.6
-        version: 2.4.6
+        specifier: ^2.4.11
+        version: 2.4.11(@vue/compiler-dom@3.5.38)(@vue/server-renderer@3.5.38(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3))
       '@vueuse/core':
-        specifier: ^14.2.1
-        version: 14.2.1(vue@3.5.31(typescript@6.0.2))
+        specifier: ^14.3.0
+        version: 14.3.0(vue@3.5.38(typescript@6.0.3))
       copy:
         specifier: ^0.3.2
         version: 0.3.2
       eslint:
-        specifier: ^10.1.0
-        version: 10.1.0
+        specifier: ^10.5.0
+        version: 10.5.0
       happy-dom:
-        specifier: ^20.8.8
-        version: 20.8.8
+        specifier: ^20.10.4
+        version: 20.10.4
       pinia:
         specifier: ^3.0.4
-        version: 3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2))
+        version: 3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3))
       typescript:
-        specifier: 6.0.2
-        version: 6.0.2
+        specifier: 6.0.3
+        version: 6.0.3
       unplugin-dts:
-        specifier: 1.0.0-beta.6
-        version: 1.0.0-beta.6(@microsoft/api-extractor@7.57.7(@types/node@25.5.0))(@vue/language-core@3.2.6)(typescript@6.0.2)(vite@8.0.3(@types/node@25.5.0)(yaml@2.8.3))
+        specifier: 1.0.2
+        version: 1.0.2(@microsoft/api-extractor@7.57.7(@types/node@25.9.3))(@vue/language-core@3.3.5)(rolldown@1.0.3)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(yaml@2.8.3))
       vite:
-        specifier: ^8.0.3
-        version: 8.0.3(@types/node@25.5.0)(yaml@2.8.3)
+        specifier: ^8.0.16
+        version: 8.0.16(@types/node@25.9.3)(yaml@2.8.3)
       vitest:
-        specifier: ^4.1.1
-        version: 4.1.1(@types/node@25.5.0)(happy-dom@20.8.8)(vite@8.0.3(@types/node@25.5.0)(yaml@2.8.3))
+        specifier: ^4.1.9
+        version: 4.1.9(@types/node@25.9.3)(happy-dom@20.10.4)(vite@8.0.16(@types/node@25.9.3)(yaml@2.8.3))
       vitest-fetch-mock:
         specifier: ^0.4.5
-        version: 0.4.5(vitest@4.1.1(@types/node@25.5.0)(happy-dom@20.8.8)(vite@8.0.3(@types/node@25.5.0)(yaml@2.8.3)))
+        version: 0.4.5(vitest@4.1.9(@types/node@25.9.3)(happy-dom@20.10.4)(vite@8.0.16(@types/node@25.9.3)(yaml@2.8.3)))
       vue:
-        specifier: ^3.5.31
-        version: 3.5.31(typescript@6.0.2)
+        specifier: ^3.5.38
+        version: 3.5.38(typescript@6.0.3)
       vue-tsc:
-        specifier: ^3.2.6
-        version: 3.2.6(typescript@6.0.2)
+        specifier: ^3.3.5
+        version: 3.3.5(typescript@6.0.3)
 
 packages:
 
-  '@antfu/eslint-config@7.7.3':
-    resolution: {integrity: sha512-BtroDxTvmWtvr3yJkdWVCvwsKlnEdkreoeOyrdNezc/W5qaiQNf2xjcsQ3N5Yy0x27h+0WFfW8rG8YlVioG6dw==}
+  '@antfu/eslint-config@9.0.0':
+    resolution: {integrity: sha512-8aQW0UWHoNMdVxTfzs1+w10t26plsc9oFs8YhCyCtST5nnANJe/VAjqvR3hYI1l3PHBeo4tjVMg8wuu6g3OLlA==}
     hasBin: true
     peerDependencies:
       '@angular-eslint/eslint-plugin': ^21.1.0
       '@angular-eslint/eslint-plugin-template': ^21.1.0
       '@angular-eslint/template-parser': ^21.1.0
-      '@eslint-react/eslint-plugin': ^2.11.0
+      '@eslint-react/eslint-plugin': ^5.6.0
       '@next/eslint-plugin-next': '>=15.0.0'
       '@prettier/plugin-xml': ^3.4.1
       '@unocss/eslint-plugin': '>=0.50.0'
@@ -87,7 +90,6 @@ packages:
       eslint-plugin-astro: ^1.2.0
       eslint-plugin-format: '>=0.1.0'
       eslint-plugin-jsx-a11y: '>=6.10.2'
-      eslint-plugin-react-hooks: ^7.0.0
       eslint-plugin-react-refresh: ^0.5.0
       eslint-plugin-solid: ^0.14.3
       eslint-plugin-svelte: '>=2.35.1'
@@ -118,8 +120,6 @@ packages:
         optional: true
       eslint-plugin-jsx-a11y:
         optional: true
-      eslint-plugin-react-hooks:
-        optional: true
       eslint-plugin-react-refresh:
         optional: true
       eslint-plugin-solid:
@@ -142,8 +142,16 @@ packages:
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/parser@7.29.2':
@@ -151,38 +159,53 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
-  '@clack/core@1.1.0':
-    resolution: {integrity: sha512-SVcm4Dqm2ukn64/8Gub2wnlA5nS2iWJyCkdNHcvNHPIeBTGojpdJ+9cZKwLfmqy7irD4N5qLteSilJlE0WLAtA==}
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
 
-  '@clack/prompts@1.1.0':
-    resolution: {integrity: sha512-pkqbPGtohJAvm4Dphs2M8xE29ggupihHdy1x84HNojZuMtFsHiUlRvqD24tM2+XmI+61LlfNceM3Wr7U5QES5g==}
+  '@clack/core@1.4.1':
+    resolution: {integrity: sha512-FILJa1gGKEFTGZAJE9RpVhrjKz3c3h4ar60dSv6cGuDqufQ84YEIS3GAGvZiN+H6yaLbbvTFNejjCC4tXpZEuw==}
+    engines: {node: '>= 20.12.0'}
 
-  '@e18e/eslint-plugin@0.2.0':
-    resolution: {integrity: sha512-mXgODVwhuDjTJ+UT+XSvmMmCidtGKfrV5nMIv1UtpWex2pYLsIM3RSpT8HWIMAebS9qANbXPKlSX4BE7ZvuCgA==}
+  '@clack/prompts@1.5.1':
+    resolution: {integrity: sha512-zccHj2z2oCCO4yrDiRSlFOxWerGqRiysP7a5jPK6uoI9URKAquwY42Dd/iUP8JWHxEzdRe4TlbvZCo8z1/mhrw==}
+    engines: {node: '>= 20.12.0'}
+
+  '@e18e/eslint-plugin@0.4.1':
+    resolution: {integrity: sha512-Re00N8ad1HsNrzpuIX7Bhdr8RSaFWp6VgwJUEJF+47+D1CMcXoS7VNRkIG23e46pddhgxWU0cWk4wYiQIuMHqQ==}
     peerDependencies:
       eslint: ^9.0.0 || ^10.0.0
-      oxlint: ^1.41.0
+      oxlint: ^1.61.0
     peerDependenciesMeta:
       eslint:
         optional: true
       oxlint:
         optional: true
 
-  '@emnapi/core@1.9.1':
-    resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
-  '@emnapi/runtime@1.9.1':
-    resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
-  '@emnapi/wasi-threads@1.2.0':
-    resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@es-joy/jsdoccomment@0.84.0':
     resolution: {integrity: sha512-0xew1CxOam0gV5OMjh2KjFQZsKL2bByX1+q4j3E73MpYIdyUxcZb/xQct9ccUb+ve5KGUYbCUxyPnYB7RbuP+w==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@es-joy/jsdoccomment@0.86.0':
+    resolution: {integrity: sha512-ukZmRQ81WiTpDWO6D/cTBM7XbrNtutHKvAVnZN/8pldAwLoJArGOvkNyxPTBGsPjsoaQBJxlH+tE2TNA/92Qgw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@es-joy/resolve.exports@1.2.0':
@@ -195,21 +218,11 @@ packages:
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
 
-  '@eslint-community/eslint-utils@4.9.0':
-    resolution: {integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-
-  '@eslint-community/regexpp@4.12.1':
-    resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
-    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
   '@eslint-community/regexpp@4.12.2':
     resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
@@ -224,36 +237,40 @@ packages:
       eslint:
         optional: true
 
-  '@eslint/config-array@0.23.3':
-    resolution: {integrity: sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==}
+  '@eslint/config-array@0.23.5':
+    resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@eslint/config-helpers@0.5.3':
-    resolution: {integrity: sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==}
+  '@eslint/config-helpers@0.5.5':
+    resolution: {integrity: sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@eslint/core@0.17.0':
-    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  '@eslint/config-helpers@0.6.0':
+    resolution: {integrity: sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@eslint/core@1.1.1':
     resolution: {integrity: sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@eslint/markdown@7.5.1':
-    resolution: {integrity: sha512-R8uZemG9dKTbru/DQRPblbJyXpObwKzo8rv1KYGGuPUPtjM4LXBYM9q5CIZAComzZupws3tWbDwam5AFpPLyJQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@eslint/object-schema@3.0.3':
-    resolution: {integrity: sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==}
+  '@eslint/core@1.2.1':
+    resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@eslint/plugin-kit@0.4.1':
-    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  '@eslint/markdown@8.0.2':
+    resolution: {integrity: sha512-W+/0qHp0WbvFEljUvvECNpSWrUHpBWIWwp7F3QqEwQKmaRCmfEWvk6VfUia9pTQ0th6HyBGBsPfg/kG3/aQxLA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/object-schema@3.0.5':
+    resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@eslint/plugin-kit@0.6.1':
     resolution: {integrity: sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/plugin-kit@0.7.2':
+    resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@humanfs/core@0.19.1':
@@ -315,8 +332,11 @@ packages:
       eslint: ^9 || ^10
       vite: ^4 || ^5 || ^6 || ^7 || ^8
 
-  '@napi-rs/wasm-runtime@1.1.1':
-    resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
+  '@napi-rs/wasm-runtime@1.1.5':
+    resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
 
   '@one-ini/wasm@0.1.1':
     resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
@@ -325,8 +345,8 @@ packages:
     resolution: {integrity: sha512-XRO0zi2NIUKq2lUk3T1ecFSld1fMWRKE6naRFGkgkdeosx7IslyUKNv5Dcb5PJTja9tHJoFu0v/7yEpAkrkrTg==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@oxc-project/types@0.122.0':
-    resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
+  '@oxc-project/types@0.133.0':
+    resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
 
   '@pinia/testing@1.0.3':
     resolution: {integrity: sha512-g+qR49GNdI1Z8rZxKrQC3GN+LfnGTNf5Kk8Nz5Cz6mIGva5WRS+ffPXQfzhA0nu6TveWzPNYTjGl4nJqd3Cu9Q==}
@@ -341,106 +361,103 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.12':
-    resolution: {integrity: sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==}
+  '@rolldown/binding-android-arm64@1.0.3':
+    resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
-    resolution: {integrity: sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==}
+  '@rolldown/binding-darwin-arm64@1.0.3':
+    resolution: {integrity: sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.12':
-    resolution: {integrity: sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==}
+  '@rolldown/binding-darwin-x64@1.0.3':
+    resolution: {integrity: sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
-    resolution: {integrity: sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==}
+  '@rolldown/binding-freebsd-x64@1.0.3':
+    resolution: {integrity: sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12':
-    resolution: {integrity: sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
+    resolution: {integrity: sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
-    resolution: {integrity: sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+    resolution: {integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
-    resolution: {integrity: sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==}
+  '@rolldown/binding-linux-arm64-musl@1.0.3':
+    resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
-    resolution: {integrity: sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==}
+  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
+    resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
-    resolution: {integrity: sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==}
+  '@rolldown/binding-linux-s390x-gnu@1.0.3':
+    resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
-    resolution: {integrity: sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==}
+  '@rolldown/binding-linux-x64-gnu@1.0.3':
+    resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
-    resolution: {integrity: sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==}
+  '@rolldown/binding-linux-x64-musl@1.0.3':
+    resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
-    resolution: {integrity: sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==}
+  '@rolldown/binding-openharmony-arm64@1.0.3':
+    resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12':
-    resolution: {integrity: sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==}
-    engines: {node: '>=14.0.0'}
+  '@rolldown/binding-wasm32-wasi@1.0.3':
+    resolution: {integrity: sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
-    resolution: {integrity: sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.3':
+    resolution: {integrity: sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.12':
-    resolution: {integrity: sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==}
+  '@rolldown/binding-win32-x64-msvc@1.0.3':
+    resolution: {integrity: sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/pluginutils@1.0.0-rc.12':
-    resolution: {integrity: sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==}
-
-  '@rolldown/pluginutils@1.0.0-rc.2':
-    resolution: {integrity: sha512-izyXV/v+cHiRfozX62W9htOAvwMo4/bXKDrQ+vom1L1qRuexPock/7VZDAhnpHCLNejd3NJ6hiab+tO0D44Rgw==}
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
   '@rollup/pluginutils@5.3.0':
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
@@ -494,8 +511,8 @@ packages:
     peerDependencies:
       eslint: ^9.0.0 || ^10.0.0
 
-  '@tybys/wasm-util@0.10.1':
-    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+  '@tybys/wasm-util@0.10.2':
+    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
   '@types/argparse@1.0.38':
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
@@ -518,8 +535,14 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/katex@0.16.8':
+    resolution: {integrity: sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==}
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
@@ -529,6 +552,9 @@ packages:
 
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
+
+  '@types/node@25.9.3':
+    resolution: {integrity: sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -542,13 +568,13 @@ packages:
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
-  '@typescript-eslint/eslint-plugin@8.57.2':
-    resolution: {integrity: sha512-NZZgp0Fm2IkD+La5PR81sd+g+8oS6JwJje+aRWsDocxHkjyRw0J5L5ZTlN3LI1LlOcGL7ph3eaIUmTXMIjLk0w==}
+  '@typescript-eslint/eslint-plugin@8.61.0':
+    resolution: {integrity: sha512-bFNvl9ZczlVb+wR2Akszf3gHfKVj/8WanXaGJ3UstTA7brNKg0cNdk6X1Psu5V7MZ2oQtzZKOEzIUehaoxbDGw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.57.2
+      '@typescript-eslint/parser': ^8.61.0
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/parser@8.57.2':
     resolution: {integrity: sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==}
@@ -557,11 +583,24 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.0.0'
 
+  '@typescript-eslint/parser@8.61.0':
+    resolution: {integrity: sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/project-service@8.57.2':
     resolution: {integrity: sha512-FuH0wipFywXRTHf+bTTjNyuNQQsQC3qh/dYzaM4I4W0jrCqjCVuUh99+xd9KamUfmCGPvbO8NDngo/vsnNVqgw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/project-service@8.61.0':
+    resolution: {integrity: sha512-DV42F7MLJO6Rax7SK1yg43tcnEfGUrurSpSxKuVX+a3RCTzBlH3fuxprrOJXKCJGAaw82xXocikJ0uQaqwXgGA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/rule-tester@8.57.2':
     resolution: {integrity: sha512-cb5m0irr1449waTuYzGi4KD3SGUH3khL4ta/o9lzShvT7gnIwR5qVhU0VM0p966kCrtFId8hwmkvz1fOElsxTg==}
@@ -573,21 +612,35 @@ packages:
     resolution: {integrity: sha512-snZKH+W4WbWkrBqj4gUNRIGb/jipDW3qMqVJ4C9rzdFc+wLwruxk+2a5D+uoFcKPAqyqEnSb4l2ULuZf95eSkw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/scope-manager@8.61.0':
+    resolution: {integrity: sha512-IWdXFHFSb6mlC3HPc7QsLDm5zYEbUla6trDEHf32D3/dnuUyXd87plScSNXSbm0/RxMvObpI17sv/EDTGrGZkA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/tsconfig-utils@8.57.2':
     resolution: {integrity: sha512-3Lm5DSM+DCowsUOJC+YqHHnKEfFh5CoGkj5Z31NQSNF4l5wdOwqGn99wmwN/LImhfY3KJnmordBq/4+VDe2eKw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/type-utils@8.57.2':
-    resolution: {integrity: sha512-Co6ZCShm6kIbAM/s+oYVpKFfW7LBc6FXoPXjTRQ449PPNBY8U0KZXuevz5IFuuUj2H9ss40atTaf9dlGLzbWZg==}
+  '@typescript-eslint/tsconfig-utils@8.61.0':
+    resolution: {integrity: sha512-O5Amvdv9ztMpxpf+vmFULGG78IE6Qwdr3bCGvqwG4nwc9H2qXkOYJJnRbRHyMkQTjv1d03olqwwwzHLMqpFePQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.61.0':
+    resolution: {integrity: sha512-TuBiQYIkd97yBfInHCTKVYMbX4kvEmpOEuixIuzCU9p8BGT1SfyyO0d0IfDMbPIHcjn/hWnusUX5e8v5Xg+X8A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/types@8.57.2':
     resolution: {integrity: sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/types@8.61.0':
+    resolution: {integrity: sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@8.57.2':
@@ -596,6 +649,12 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
+  '@typescript-eslint/typescript-estree@8.61.0':
+    resolution: {integrity: sha512-42zatd5qSvvcV1JdDBCLxYRznvP4eIHpPoZXdkPFnAmanA4FuZ5dibSnCBggY8hQnqajPpoGjXFdZ7fIJKQnlA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/utils@8.57.2':
     resolution: {integrity: sha512-krRIbvPK1ju1WBKIefiX+bngPs+odIQUtR7kymzPfo1POVw3jlF+nLkmexdSSd4UCbDcQn+wMBATOOmpBbqgKg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -603,19 +662,30 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.0.0'
 
+  '@typescript-eslint/utils@8.61.0':
+    resolution: {integrity: sha512-3bzFt7ImFMW/jVYwJamDoe/dMOdFLSC6pom6rRjdh4SZJEYupyMzem8e7vKZLclLfpHjlwSAXOUxtKxGXUiLqA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/visitor-keys@8.57.2':
     resolution: {integrity: sha512-zhahknjobV2FiD6Ee9iLbS7OV9zi10rG26odsQdfBO/hjSzUQbkIYgda+iNKK1zNiW2ey+Lf8MU5btN17V3dUw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@vitejs/plugin-vue@6.0.5':
-    resolution: {integrity: sha512-bL3AxKuQySfk1iGcBsQnoRVexTPJq0Z/ixFVM8OhVJAP6ZXXXLtM7NFKWhLl30Kg7uTBqIaPXbh+nuQCuBDedg==}
+  '@typescript-eslint/visitor-keys@8.61.0':
+    resolution: {integrity: sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@vitejs/plugin-vue@6.0.7':
+    resolution: {integrity: sha512-km+p+XdSz9Sxm5rqUbqcSfZYaAniKxWBj1KURl+Jr7UaPvvX7BmaWMdP69I5rrFDeQGyxAG7NXdc57vz+snhWg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       vue: ^3.2.25
 
-  '@vitest/eslint-plugin@1.6.13':
-    resolution: {integrity: sha512-ui7JGWBoQpS5NKKW0FDb1eTuFEZ5EupEv2Psemuyfba7DfA5K52SeDLelt6P4pQJJ/4UGkker/BgMk/KrjH3WQ==}
+  '@vitest/eslint-plugin@1.6.20':
+    resolution: {integrity: sha512-xRwWHFG0Utp6hXtbGiWk4VdKXCGdExD8kbWrrmFEiG5dk8anOJ+vbWbeOa8EbkocKQRTsx7JAWETccZiBgFp/Q==}
     engines: {node: '>=18'}
     peerDependencies:
       '@typescript-eslint/eslint-plugin': '*'
@@ -630,11 +700,11 @@ packages:
       vitest:
         optional: true
 
-  '@vitest/expect@4.1.1':
-    resolution: {integrity: sha512-xAV0fqBTk44Rn6SjJReEQkHP3RrqbJo6JQ4zZ7/uVOiJZRarBtblzrOfFIZeYUrukp2YD6snZG6IBqhOoHTm+A==}
+  '@vitest/expect@4.1.9':
+    resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
 
-  '@vitest/mocker@4.1.1':
-    resolution: {integrity: sha512-h3BOylsfsCLPeceuCPAAJ+BvNwSENgJa4hXoXu4im0bs9Lyp4URc4JYK4pWLZ4pG/UQn7AT92K6IByi6rE6g3A==}
+  '@vitest/mocker@4.1.9':
+    resolution: {integrity: sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -644,20 +714,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.1':
-    resolution: {integrity: sha512-GM+TEQN5WhOygr1lp7skeVjdLPqqWMHsfzXrcHAqZJi/lIVh63H0kaRCY8MDhNWikx19zBUK8ceaLB7X5AH9NQ==}
+  '@vitest/pretty-format@4.1.9':
+    resolution: {integrity: sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==}
 
-  '@vitest/runner@4.1.1':
-    resolution: {integrity: sha512-f7+FPy75vN91QGWsITueq0gedwUZy1fLtHOCMeQpjs8jTekAHeKP80zfDEnhrleviLHzVSDXIWuCIOFn3D3f8A==}
+  '@vitest/runner@4.1.9':
+    resolution: {integrity: sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==}
 
-  '@vitest/snapshot@4.1.1':
-    resolution: {integrity: sha512-kMVSgcegWV2FibXEx9p9WIKgje58lcTbXgnJixfcg15iK8nzCXhmalL0ZLtTWLW9PH1+1NEDShiFFedB3tEgWg==}
+  '@vitest/snapshot@4.1.9':
+    resolution: {integrity: sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==}
 
-  '@vitest/spy@4.1.1':
-    resolution: {integrity: sha512-6Ti/KT5OVaiupdIZEuZN7l3CZcR0cxnxt70Z0//3CtwgObwA6jZhmVBA3yrXSVN3gmwjgd7oDNLlsXz526gpRA==}
+  '@vitest/spy@4.1.9':
+    resolution: {integrity: sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==}
 
-  '@vitest/utils@4.1.1':
-    resolution: {integrity: sha512-cNxAlaB3sHoCdL6pj6yyUXv9Gry1NHNg0kFTXdvSIZXLHsqKH7chiWOkwJ5s5+d/oMwcoG9T0bKU38JZWKusrQ==}
+  '@vitest/utils@4.1.9':
+    resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
 
   '@volar/language-core@2.4.28':
     resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
@@ -668,27 +738,27 @@ packages:
   '@volar/typescript@2.4.28':
     resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
 
-  '@volverjs/data@2.0.4':
-    resolution: {integrity: sha512-KcCUF7ZFkWJqJnUmDg4fBtfjn470RhKBC1AJkhUpYzM8mml42Qrz+KRnBrSkDkXKh62chZo4YeRSBca/zoA2eA==}
+  '@volverjs/data@2.0.5':
+    resolution: {integrity: sha512-R6OH1Nazjtaa399OsE4/FSPXRoQXjjlamlOYVIxaENkt0vvO+0xzPuJCGW79cnwQKFkXK6cQfROzrM7T/0k45Q==}
     engines: {node: '>= 16.x'}
-
-  '@vue/compiler-core@3.5.30':
-    resolution: {integrity: sha512-s3DfdZkcu/qExZ+td75015ljzHc6vE+30cFMGRPROYjqkroYI5NV2X1yAMX9UeyBNWB9MxCfPcsjpLS11nzkkw==}
 
   '@vue/compiler-core@3.5.31':
     resolution: {integrity: sha512-k/ueL14aNIEy5Onf0OVzR8kiqF/WThgLdFhxwa4e/KF/0qe38IwIdofoSWBTvvxQOesaz6riAFAUaYjoF9fLLQ==}
 
-  '@vue/compiler-dom@3.5.30':
-    resolution: {integrity: sha512-eCFYESUEVYHhiMuK4SQTldO3RYxyMR/UQL4KdGD1Yrkfdx4m/HYuZ9jSfPdA+nWJY34VWndiYdW/wZXyiPEB9g==}
+  '@vue/compiler-core@3.5.38':
+    resolution: {integrity: sha512-s99aGxWYig9ErHbct27KXEGhrBYlRI6c4MwAgXErOAbX9xiW37/uMa+XUDO69zLz83dng8UUZ70CTOJrLrYrEQ==}
 
   '@vue/compiler-dom@3.5.31':
     resolution: {integrity: sha512-BMY/ozS/xxjYqRFL+tKdRpATJYDTTgWSo0+AJvJNg4ig+Hgb0dOsHPXvloHQ5hmlivUqw1Yt2pPIqp4e0v1GUw==}
 
-  '@vue/compiler-sfc@3.5.31':
-    resolution: {integrity: sha512-M8wpPgR9UJ8MiRGjppvx9uWJfLV7A/T+/rL8s/y3QG3u0c2/YZgff3d6SuimKRIhcYnWg5fTfDMlz2E6seUW8Q==}
+  '@vue/compiler-dom@3.5.38':
+    resolution: {integrity: sha512-JTqp25l8aFfJYF7/KmsXZjAxJz7T+SjmTJLoXVjHtc2BrSgSiW2n9Aem/cWq1OPe68A8JL06B3eVdhlP0H4TVw==}
 
-  '@vue/compiler-ssr@3.5.31':
-    resolution: {integrity: sha512-h0xIMxrt/LHOvJKMri+vdYT92BrK3HFLtDqq9Pr/lVVfE4IyKZKvWf0vJFW10Yr6nX02OR4MkJwI0c1HDa1hog==}
+  '@vue/compiler-sfc@3.5.38':
+    resolution: {integrity: sha512-DuA2GiZawSEW442iw/9+Fkol8hTgb4Ke5KkhmSry65QA7YuyMbIdy8p0XZRMvNwJdgRz307W8g1CSzdvS4nuNg==}
+
+  '@vue/compiler-ssr@3.5.38':
+    resolution: {integrity: sha512-7s+W5Gc42FGxZMcuwl8H5B29T8BJPMdBT7KHFE+BbAuZ/iTEdTtv7z2XiMjiaUUw4w3ZcCEdHs36RuYJ2VA7bA==}
 
   '@vue/devtools-api@7.7.9':
     resolution: {integrity: sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==}
@@ -699,42 +769,49 @@ packages:
   '@vue/devtools-shared@7.7.9':
     resolution: {integrity: sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==}
 
-  '@vue/language-core@3.2.6':
-    resolution: {integrity: sha512-xYYYX3/aVup576tP/23sEUpgiEnujrENaoNRbaozC1/MA9I6EGFQRJb4xrt/MmUCAGlxTKL2RmT8JLTPqagCkg==}
+  '@vue/language-core@3.3.5':
+    resolution: {integrity: sha512-UkKu5nhX89fg4VhlG/FOeI10G3cj/7radKT/cy9BT4Q9qJmJlSTAc/dP63Xqs29aypN4f39xUV6PsLNk/dcD6g==}
 
-  '@vue/reactivity@3.5.31':
-    resolution: {integrity: sha512-DtKXxk9E/KuVvt8VxWu+6Luc9I9ETNcqR1T1oW1gf02nXaZ1kuAx58oVu7uX9XxJR0iJCro6fqBLw9oSBELo5g==}
+  '@vue/reactivity@3.5.38':
+    resolution: {integrity: sha512-pG6LV/NDNRbKizcUjFFLAfjaL8mcv4DmR9avNcUw2gDHBzZneuS2TWCmp633ynzxz9YYKNeEPK2I8Wraqy2HUQ==}
 
-  '@vue/runtime-core@3.5.31':
-    resolution: {integrity: sha512-AZPmIHXEAyhpkmN7aWlqjSfYynmkWlluDNPHMCZKFHH+lLtxP/30UJmoVhXmbDoP1Ng0jG0fyY2zCj1PnSSA6Q==}
+  '@vue/runtime-core@3.5.38':
+    resolution: {integrity: sha512-iyW8WVfF1CpCXxncZY5Ei6rSd6oZr5DgEom//fUjRBRl56AXPD+s9ATvukRt77ZFTuYlnVA1bxY+dJB94tWVYw==}
 
-  '@vue/runtime-dom@3.5.31':
-    resolution: {integrity: sha512-xQJsNRmGPeDCJq/u813tyonNgWBFjzfVkBwDREdEWndBnGdHLHgkwNBQxLtg4zDrzKTEcnikUy1UUNecb3lJ6g==}
+  '@vue/runtime-dom@3.5.38':
+    resolution: {integrity: sha512-apX2wt9sdfDshS+a2xueFZLVpt0GkRJZSoPmrW/SA4yzXTznhfcMVW59gr7h4YQeY0vJhdJkk2rsIDwgfFgC5A==}
 
-  '@vue/server-renderer@3.5.31':
-    resolution: {integrity: sha512-GJuwRvMcdZX/CriUnyIIOGkx3rMV3H6sOu0JhdKbduaeCji6zb60iOGMY7tFoN24NfsUYoFBhshZtGxGpxO4iA==}
+  '@vue/server-renderer@3.5.38':
+    resolution: {integrity: sha512-vue8vbf2QlV4quHqzwmJy6dWfmRhP1J8l4wtZg60CL6VoKqcPY2oe7may3+1d9qfpedjK5PRLFqd5k3Isj9mUw==}
     peerDependencies:
-      vue: 3.5.31
-
-  '@vue/shared@3.5.30':
-    resolution: {integrity: sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ==}
+      vue: 3.5.38
 
   '@vue/shared@3.5.31':
     resolution: {integrity: sha512-nBxuiuS9Lj5bPkPbWogPUnjxxWpkRniX7e5UBQDWl6Fsf4roq9wwV+cR7ezQ4zXswNvPIlsdj1slcLB7XCsRAw==}
 
-  '@vue/test-utils@2.4.6':
-    resolution: {integrity: sha512-FMxEjOpYNYiFe0GkaHsnJPXFHxQ6m4t8vI/ElPGpMWxZKpmRvQ33OIrvRXemy6yha03RxhOlQuy+gZMC3CQSow==}
+  '@vue/shared@3.5.38':
+    resolution: {integrity: sha512-FTW0AFZNaK5/mOqvGBwVfUlNLU38TiQn4+DQgIFUnrBBJQ1crMJ82yeGQLV5jyKFsO8yRukpbuP7x+nRbH6aug==}
 
-  '@vueuse/core@14.2.1':
-    resolution: {integrity: sha512-3vwDzV+GDUNpdegRY6kzpLm4Igptq+GA0QkJ3W61Iv27YWwW/ufSlOfgQIpN6FZRMG0mkaz4gglJRtq5SeJyIQ==}
+  '@vue/test-utils@2.4.11':
+    resolution: {integrity: sha512-GDqaqZsA6m2E5vNzej0aYiIb6BX8xV9pNSbbbXKOfEYwg7ZNblVX8suyqmUBThq8VIrgAJNxn+z72hVtUeiWHA==}
+    peerDependencies:
+      '@vue/compiler-dom': 3.x
+      '@vue/server-renderer': 3.x
+      vue: 3.x
+    peerDependenciesMeta:
+      '@vue/server-renderer':
+        optional: true
+
+  '@vueuse/core@14.3.0':
+    resolution: {integrity: sha512-aHfz47g0ZhMtTVHmIzMVpJy8ePhhOy68GY5bv110+5DVtZ+W7BsOx+m61UNQqfrWyPztIHIanWa3E2tib3NFIw==}
     peerDependencies:
       vue: ^3.5.0
 
-  '@vueuse/metadata@14.2.1':
-    resolution: {integrity: sha512-1ButlVtj5Sb/HDtIy1HFr1VqCP4G6Ypqt5MAo0lCgjokrk2mvQKsK2uuy0vqu/Ks+sHfuHo0B9Y9jn9xKdjZsw==}
+  '@vueuse/metadata@14.3.0':
+    resolution: {integrity: sha512-BwxmbAzwAVF50+MW57GXOUEV61nFBGnlBvrTqj49PqWJu3uw7hdu72ztXeZ33RdZtDY6kO+bfCAE1PCn88Tktw==}
 
-  '@vueuse/shared@14.2.1':
-    resolution: {integrity: sha512-shTJncjV9JTI4oVNyF1FQonetYAiTBd+Qj7cY89SWbXSkx7gyhrgtEdF2ZAVWS1S3SHlaROO6F2IesJxQEkZBw==}
+  '@vueuse/shared@14.3.0':
+    resolution: {integrity: sha512-bZpge9eSXwa4ToSiqJ7j6KRwhAsneMFoSz3LMWKQDkqimm3D/tbFlrklrs/IOqC8tEcYmXQZJ6N0UrjhBirVCg==}
     peerDependencies:
       vue: ^3.5.0
 
@@ -750,11 +827,6 @@ packages:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
-
-  acorn@8.15.0:
-    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
 
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
@@ -783,8 +855,8 @@ packages:
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
-  alien-signals@3.0.0:
-    resolution: {integrity: sha512-JHoRJf18Y6HN4/KZALr3iU+0vW9LKG+8FMThQlbn4+gv8utsLIkwpomjElGPccGeNwh0FI2HN6BLnyFLo6OyLQ==}
+  alien-signals@3.2.1:
+    resolution: {integrity: sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==}
 
   ansi-green@0.1.1:
     resolution: {integrity: sha512-WJ70OI4jCaMy52vGa/ypFSKFb/TrYNPaQ2xco5nUwE0C5H8piume/uAZNNdXXiMQ6DbRmiE7l8oNBHu05ZKkrw==}
@@ -868,6 +940,10 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  buffer-image-size@0.6.4:
+    resolution: {integrity: sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==}
+    engines: {node: '>=4.0'}
+
   builtin-modules@5.0.0:
     resolution: {integrity: sha512-bkXY9WsVpY7CvMhKSR6pZilZu9Ln5WDrKVBUXf2S443etkmEO4V58heTecXcUIsNsi4Rx8JUO4NfX1IcQl4deg==}
     engines: {node: '>=18.20'}
@@ -930,12 +1006,16 @@ packages:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
     engines: {node: '>=14'}
 
-  comment-parser@1.4.1:
-    resolution: {integrity: sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==}
-    engines: {node: '>= 12.0.0'}
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
 
   comment-parser@1.4.5:
     resolution: {integrity: sha512-aRDkn3uyIlCFfk5NUA+VdwMmMsh8JGhc4hapfV4yxymHGQ3BVskMQfoXGpCo5IoBuQ9tS5iiVKhCpTcB4pW4qw==}
+    engines: {node: '>= 12.0.0'}
+
+  comment-parser@1.4.6:
+    resolution: {integrity: sha512-ObxuY6vnbWTN6Od72xfwN9DbzC7Y2vv8u1Soi9ahRKL37gb6y1qk6/dgjs+3JWuXJHWvsg3BXIwzd/rkmAwavg==}
     engines: {node: '>= 12.0.0'}
 
   compare-versions@6.1.1:
@@ -1100,8 +1180,8 @@ packages:
     peerDependencies:
       eslint: ^9.5.0 || ^10.0.0
 
-  eslint-flat-config-utils@3.0.2:
-    resolution: {integrity: sha512-mPvevWSDQFwgABvyCurwIu6ZdKxGI5NW22/BGDwA1T49NO6bXuxbV9VfJK/tkQoNyPogT6Yu1d57iM0jnZVWmg==}
+  eslint-flat-config-utils@3.2.0:
+    resolution: {integrity: sha512-PHgo1X5uqIorJONLVD9BIaOSdoYFD3z/AeJljdqDPlWVRpeCYkDbK9k0AXoYVqqNJr6FEYIEr5Rm2TSktLQcHw==}
 
   eslint-json-compat-utils@0.2.3:
     resolution: {integrity: sha512-RbBmDFyu7FqnjE8F0ZxPNzx5UaptdeS9Uu50r7A+D7s/+FCX+ybiyViYEgFUaFIFqSWJgZRTpL5d8Kanxxl2lQ==}
@@ -1119,8 +1199,8 @@ packages:
     peerDependencies:
       eslint: '*'
 
-  eslint-plugin-antfu@3.2.2:
-    resolution: {integrity: sha512-Qzixht2Dmd/pMbb5EnKqw2V8TiWHbotPlsORO8a+IzCLFwE0RxK8a9k4DCTFPzBwyxJzH+0m2Mn8IUGeGQkyUw==}
+  eslint-plugin-antfu@3.2.3:
+    resolution: {integrity: sha512-U2fnz/H0gFPxpuC7QpaHa0Jv2AgCZ5hunp36SOP/yWo8yFzgvMh8X4pZ4uN4IKoqtBhk7G3HuVa93Urf51+sZg==}
     peerDependencies:
       eslint: '*'
 
@@ -1132,25 +1212,20 @@ packages:
       '@typescript-eslint/utils': '*'
       eslint: '*'
 
-  eslint-plugin-depend@1.5.0:
-    resolution: {integrity: sha512-i3UeLYmclf1Icp35+6W7CR4Bp2PIpDgBuf/mpmXK5UeLkZlvYJ21VuQKKHHAIBKRTPivPGX/gZl5JGno1o9Y0A==}
-    peerDependencies:
-      eslint: '>=8.40.0'
-
   eslint-plugin-es-x@7.8.0:
     resolution: {integrity: sha512-7Ds8+wAAoV3T+LAKeu39Y5BzXCrGKrcISfgKEqTS4BDN8SFEDQd0S43jiQ8vIa3wUKD07qitZdfzlenSi8/0qQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       eslint: '>=8'
 
-  eslint-plugin-import-lite@0.5.2:
-    resolution: {integrity: sha512-XvfdWOC5dSLEI9krIPRlNmKSI2ViIE9pVylzfV9fCq0ZpDaNeUk6o0wZv0OzN83QdadgXp1NsY0qjLINxwYCsw==}
+  eslint-plugin-import-lite@0.6.0:
+    resolution: {integrity: sha512-80vevx2A7i3H7n1/6pqDO8cc5wRz6OwLDvIyVl9UflBV1N1f46e9Ihzi65IOLYoSxM6YykK2fTw1xm0Ixx6aTQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: '>=9.0.0'
+      eslint: ^9.0.0 || ^10.0.0
 
-  eslint-plugin-jsdoc@62.8.0:
-    resolution: {integrity: sha512-hu3r9/6JBmPG6wTcqtYzgZAnjEG2eqRUATfkFscokESg1VDxZM21ZaMire0KjeMwfj+SXvgB4Rvh5LBuesj92w==}
+  eslint-plugin-jsdoc@62.9.0:
+    resolution: {integrity: sha512-PY7/X4jrVgoIDncUmITlUqK546Ltmx/Pd4Hdsu4CvSjryQZJI2mEV4vrdMufyTetMiZ5taNSqvK//BTgVUlNkA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
@@ -1161,18 +1236,25 @@ packages:
     peerDependencies:
       eslint: '>=9.38.0'
 
-  eslint-plugin-n@17.24.0:
-    resolution: {integrity: sha512-/gC7/KAYmfNnPNOb3eu8vw+TdVnV0zhdQwexsw6FLXbhzroVj20vRn2qL8lDWDGnAQ2J8DhdfvXxX9EoxvERvw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  eslint-plugin-n@18.1.0:
+    resolution: {integrity: sha512-hkUm9EtnFV2h2fE16jNVUfCVUqvPzI7fGLsFdun5lFt/pbmf2kCgDx6ymi9rx+NCUSggBmurJCZOfG20JBs/kg==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
     peerDependencies:
-      eslint: '>=8.23.0'
+      eslint: '>=8.57.1'
+      ts-declaration-location: ^1.0.6
+      typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      ts-declaration-location:
+        optional: true
+      typescript:
+        optional: true
 
-  eslint-plugin-no-only-tests@3.3.0:
-    resolution: {integrity: sha512-brcKcxGnISN2CcVhXJ/kEQlNa0MEfGRtwKtWA16SkqXHKitaKIMrfemJKLKX1YqDU5C/5JY3PvZXd5jEW04e0Q==}
+  eslint-plugin-no-only-tests@3.4.0:
+    resolution: {integrity: sha512-4S3/9Nb7A2tiMcpzEQE9bQSlpeOz6WJkgryBuou/SA8W2x2c8Zf4j0NvTKBjv6qNhF9T79tmkecm/0CHqV0UGg==}
     engines: {node: '>=5.0.0'}
 
-  eslint-plugin-perfectionist@5.7.0:
-    resolution: {integrity: sha512-WRHj7OZS/INutQ/gKN5C1ZGnMhkQ3oKZQAA2I7rl5yM8keBtSd9oj/qlJaHuwh5873FhMPqYlttcadF0YsTN7g==}
+  eslint-plugin-perfectionist@5.9.0:
+    resolution: {integrity: sha512-8TWzg02zmnBdZwCkWLi8jhzqXI+fE7Z/RwV8SL6xD45tJ8Bp3wGuYL2XtQgfe/Wd0eBqOUX+s6ey73IyszvKTA==}
     engines: {node: ^20.0.0 || >=22.0.0}
     peerDependencies:
       eslint: ^8.45.0 || ^9.0.0 || ^10.0.0
@@ -1194,8 +1276,8 @@ packages:
     peerDependencies:
       eslint: '>=9.38.0'
 
-  eslint-plugin-unicorn@63.0.0:
-    resolution: {integrity: sha512-Iqecl9118uQEXYh7adylgEmGfkn5es3/mlQTLLkd4pXkIk9CTGrAbeUux+YljSa2ohXCBmQQ0+Ej1kZaFgcfkA==}
+  eslint-plugin-unicorn@64.0.0:
+    resolution: {integrity: sha512-rNZwalHh8i0UfPlhNwg5BTUO1CMdKNmjqe+TgzOTZnpKoi8VBgsW7u9qCHIdpxEzZ1uwrJrPF0uRb7l//K38gA==}
     engines: {node: ^20.10.0 || >=21.0.0}
     peerDependencies:
       eslint: '>=9.38.0'
@@ -1209,22 +1291,22 @@ packages:
       '@typescript-eslint/eslint-plugin':
         optional: true
 
-  eslint-plugin-vue@10.8.0:
-    resolution: {integrity: sha512-f1J/tcbnrpgC8suPN5AtdJ5MQjuXbSU9pGRSSYAuF3SHoiYCOdEX6O22pLaRyLHXvDcOe+O5ENgc1owQ587agA==}
+  eslint-plugin-vue@10.9.2:
+    resolution: {integrity: sha512-4g7ZP3pYcuqd7Zp0pzUKcos0W+RkjBz4EGdhJ92FcYk6v03Ti/GK5NwjgsjxHK+98eXDbHeK7VtX1az7/8doZA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       '@stylistic/eslint-plugin': ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
       '@typescript-eslint/parser': ^7.0.0 || ^8.0.0
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      vue-eslint-parser: ^10.0.0
+      vue-eslint-parser: ^10.3.0
     peerDependenciesMeta:
       '@stylistic/eslint-plugin':
         optional: true
       '@typescript-eslint/parser':
         optional: true
 
-  eslint-plugin-yml@3.3.1:
-    resolution: {integrity: sha512-isntsZchaTqDMNNkD+CakrgA/pdUoJ45USWBKpuqfAW1MCuw731xX/vrXfoJFZU3tTFr24nCbDYmDfT2+g4QtQ==}
+  eslint-plugin-yml@3.4.0:
+    resolution: {integrity: sha512-j6U3ESrAkidkvNb3HFN2UMxke46GNp6bsJokabXCICcgomSy3YU4oED9cjzkZ58nYxWD5qnWV1b/2YlqyWMOxA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
     peerDependencies:
       eslint: '>=9.38.0'
@@ -1234,10 +1316,6 @@ packages:
     peerDependencies:
       '@vue/compiler-sfc': ^3.3.0
       eslint: '>=9.0.0'
-
-  eslint-scope@8.4.0:
-    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   eslint-scope@9.1.2:
     resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
@@ -1255,8 +1333,8 @@ packages:
     resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  eslint@10.1.0:
-    resolution: {integrity: sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==}
+  eslint@10.5.0:
+    resolution: {integrity: sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
     hasBin: true
     peerDependencies:
@@ -1272,10 +1350,6 @@ packages:
   espree@11.2.0:
     resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  esquery@1.6.0:
-    resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
-    engines: {node: '>=0.10'}
 
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
@@ -1327,8 +1401,17 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
 
   fault@2.0.1:
     resolution: {integrity: sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==}
@@ -1435,11 +1518,12 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-modules@0.2.3:
     resolution: {integrity: sha512-JeXuCbvYzYXcwE6acL9V2bAOeSIGl4dD+iwLY9iUx2VBJJ80R18HCn+JCwHM9Oegdfya3lEkGCdaRkSyc10hDA==}
@@ -1453,12 +1537,12 @@ packages:
     resolution: {integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==}
     engines: {node: '>=18'}
 
-  globals@16.4.0:
-    resolution: {integrity: sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==}
-    engines: {node: '>=18'}
-
   globals@17.4.0:
     resolution: {integrity: sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==}
+    engines: {node: '>=18'}
+
+  globals@17.6.0:
+    resolution: {integrity: sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==}
     engines: {node: '>=18'}
 
   globrex@0.1.2:
@@ -1471,8 +1555,8 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  happy-dom@20.8.8:
-    resolution: {integrity: sha512-5/F8wxkNxYtsN0bXfMwIyNLZ9WYsoOYPbmoluqVJqv8KBUbcyKZawJ7uYK4WTX8IHBLYv+VXIwfeNDPy1oKMwQ==}
+  happy-dom@20.10.4:
+    resolution: {integrity: sha512-bKrsQnFNpcjZG0UPsH7UMN7Oyp3AB42LXk2GuiQmu7l4QFxH7lsw5T1eWEtE2+vbIFrTC45sbNSB2pkB8MTfKA==}
     engines: {node: '>=20.0.0'}
 
   has-flag@4.0.0:
@@ -1634,6 +1718,10 @@ packages:
     resolution: {integrity: sha512-/2uqY7x6bsrpi3i9LVU6J89352C0rpMk0as8trXxCtvd4kPk1ke/Eyif6wqfSLvoNJqcDG9Vk4UsXgygzCt2xA==}
     engines: {node: '>=20.0.0'}
 
+  jsdoc-type-pratt-parser@7.2.0:
+    resolution: {integrity: sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw==}
+    engines: {node: '>=20.0.0'}
+
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
@@ -1657,6 +1745,10 @@ packages:
 
   jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
+
+  katex@0.16.47:
+    resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
+    hasBin: true
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -1827,6 +1919,9 @@ packages:
   mdast-util-gfm@3.1.0:
     resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
 
+  mdast-util-math@3.0.0:
+    resolution: {integrity: sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==}
+
   mdast-util-phrasing@4.1.0:
     resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
 
@@ -1862,6 +1957,9 @@ packages:
 
   micromark-extension-gfm@3.0.0:
     resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-extension-math@3.1.0:
+    resolution: {integrity: sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==}
 
   micromark-factory-destination@2.0.1:
     resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
@@ -1959,8 +2057,8 @@ packages:
   mlly@1.7.4:
     resolution: {integrity: sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==}
 
-  module-replacements@2.11.0:
-    resolution: {integrity: sha512-j5sNQm3VCpQQ7nTqGeOZtoJtV3uKERgCBm9QRhmGRiXiqkf7iRFOkfxdJRZWLkqYY8PNf4cDQF/WfXUYLENrRA==}
+  module-replacements@3.0.0-beta.8:
+    resolution: {integrity: sha512-sc8TepP9elxoOBXEpxmhPzKKjTjbswHVcmsKGbgvm3k6jZlLu/WMV/Lfmga6IGMgHU/V3WtY2s6VEgM4nTElUQ==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1968,8 +2066,8 @@ packages:
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2080,10 +2178,6 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
-    engines: {node: '>=12'}
-
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
@@ -2114,8 +2208,8 @@ packages:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
     engines: {node: '>=4'}
 
-  postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -2132,8 +2226,8 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  qs@6.14.0:
-    resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   quansync@0.2.11:
@@ -2184,8 +2278,8 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
-  rolldown@1.0.0-rc.12:
-    resolution: {integrity: sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==}
+  rolldown@1.0.3:
+    resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -2198,16 +2292,6 @@ packages:
 
   semver@7.5.4:
     resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
-  semver@7.7.1:
-    resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
-  semver@7.7.2:
-    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -2357,15 +2441,16 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@1.0.1:
-    resolution: {integrity: sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==}
-
   tinyexec@1.0.4:
     resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
     engines: {node: '>=18'}
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
   tinyrainbow@3.1.0:
@@ -2411,8 +2496,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@6.0.2:
-    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -2426,8 +2511,14 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
   unist-util-is@6.0.0:
     resolution: {integrity: sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==}
+
+  unist-util-remove-position@5.0.0:
+    resolution: {integrity: sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==}
 
   unist-util-stringify-position@4.0.0:
     resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
@@ -2442,12 +2533,12 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
-  unplugin-dts@1.0.0-beta.6:
-    resolution: {integrity: sha512-+xbFv5aVFtLZFNBAKI4+kXmd2h+T42/AaP8Bsp0YP/je/uOTN94Ame2Xt3e9isZS+Z7/hrLCLbsVJh+saqFMfQ==}
+  unplugin-dts@1.0.2:
+    resolution: {integrity: sha512-VbNiMD0LMl/t6nJueGtrCp79N7ZO1nquxj/FUybJDnKwZGsnW2wjdwBSzA3QEHujoxmxZIptsG43hL7LzXE96w==}
     peerDependencies:
       '@microsoft/api-extractor': '>=7'
       '@rspack/core': ^1
-      '@vue/language-core': ~3.0.1
+      '@vue/language-core': ~3.1.5
       esbuild: '*'
       rolldown: '*'
       rollup: '>=3'
@@ -2492,14 +2583,14 @@ packages:
     resolution: {integrity: sha512-Ci3wnR2uuSAWFMSglZuB8Z2apBdtOyz8CV7dC6/U1XbltXBC+IuutUkXQISz01P+US2ouBuesSbV6zILZ6BuzQ==}
     engines: {node: '>= 0.9'}
 
-  vite@8.0.3:
-    resolution: {integrity: sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==}
+  vite@8.0.16:
+    resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
-      '@vitejs/devtools': ^0.1.0
-      esbuild: ^0.27.0
+      '@vitejs/devtools': ^0.1.18
+      esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
       less: ^4.0.0
       sass: ^1.70.0
@@ -2541,18 +2632,20 @@ packages:
     peerDependencies:
       vitest: '>=2.0.0'
 
-  vitest@4.1.1:
-    resolution: {integrity: sha512-yF+o4POL41rpAzj5KVILUxm1GCjKnELvaqmU9TLLUbMfDzuN0UpUR9uaDs+mCtjPe+uYPksXDRLQGGPvj1cTmA==}
+  vitest@4.1.9:
+    resolution: {integrity: sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.1
-      '@vitest/browser-preview': 4.1.1
-      '@vitest/browser-webdriverio': 4.1.1
-      '@vitest/ui': 4.1.1
+      '@vitest/browser-playwright': 4.1.9
+      '@vitest/browser-preview': 4.1.9
+      '@vitest/browser-webdriverio': 4.1.9
+      '@vitest/coverage-istanbul': 4.1.9
+      '@vitest/coverage-v8': 4.1.9
+      '@vitest/ui': 4.1.9
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -2569,6 +2662,10 @@ packages:
         optional: true
       '@vitest/browser-webdriverio':
         optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
       '@vitest/ui':
         optional: true
       happy-dom:
@@ -2579,8 +2676,8 @@ packages:
   vscode-uri@3.0.8:
     resolution: {integrity: sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==}
 
-  vue-component-type-helpers@2.1.10:
-    resolution: {integrity: sha512-lfgdSLQKrUmADiSV6PbBvYgQ33KF3Ztv6gP85MfGaGaSGMTXORVaHT1EHfsqCgzRNBstPKYDmvAV9Do5CmJ07A==}
+  vue-component-type-helpers@3.3.5:
+    resolution: {integrity: sha512-Fe1jyPJoUGpJOYKOri44jduR7My4yYINOMJISuMAbmrs+L5LbIDUc8NTWZYY3EJLK0yPLuCmcd5zoCsE4k2/KA==}
 
   vue-eslint-parser@10.4.0:
     resolution: {integrity: sha512-Vxi9pJdbN3ZnVGLODVtZ7y4Y2kzAAE2Cm0CZ3ZDRvydVYxZ6VrnBhLikBsRS+dpwj4Jv4UCv21PTEwF5rQ9WXg==}
@@ -2588,14 +2685,14 @@ packages:
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
 
-  vue-tsc@3.2.6:
-    resolution: {integrity: sha512-gYW/kWI0XrwGzd0PKc7tVB/qpdeAkIZLNZb10/InizkQjHjnT8weZ/vBarZoj4kHKbUTZT/bAVgoOr8x4NsQ/Q==}
+  vue-tsc@3.3.5:
+    resolution: {integrity: sha512-Rzh/G2MmNlMSAMTiQEjDrsb4dgB/jbtEM47rVN2NtidF1dfb/q4w4QvpQBtW5+y3y5H27Hjh7deVwk+YB02fNg==}
     hasBin: true
     peerDependencies:
       typescript: '>=5.0.0'
 
-  vue@3.5.31:
-    resolution: {integrity: sha512-iV/sU9SzOlmA/0tygSmjkEN6Jbs3nPoIPFhCMLD2STrjgOU8DX7ZtzMhg4ahVwf5Rp9KoFzcXeB1ZrVbLBp5/Q==}
+  vue@3.5.38:
+    resolution: {integrity: sha512-vAMKHfImQlYSy0C+PBue4s3ERZ2xGKfgZg5GXAsLInq1dyh2H78ILVP5sK0KPFPVW4kv+OGCIvBEondcjpZp7A==}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
@@ -2606,8 +2703,8 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
-  web-streams-polyfill@4.2.0:
-    resolution: {integrity: sha512-0rYDzGOh9EZpig92umN5g5D/9A1Kff7k0/mzPSSCY8jEQeYkgRMoY7LhbXtUCWzLCMX0TUE9aoHkjFNB7D9pfA==}
+  web-streams-polyfill@4.3.0:
+    resolution: {integrity: sha512-/Gnggvj9oSrEvJbDyyPtAnxBt5fGQM2iWOKQNu7ie1OxDgK40iZpyV3TKaRiEzVj1oA1UxKnEy9XPXh6PW3eVw==}
     engines: {node: '>= 8'}
 
   webpack-virtual-modules@0.6.2:
@@ -2646,8 +2743,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -2673,11 +2770,6 @@ packages:
     resolution: {integrity: sha512-h0uDm97wvT2bokfwwTmY6kJ1hp6YDFL0nRHwNKz8s/VD1FH/vvZjAKoMUE+un0eaYBSG7/c6h+lJTP+31tjgTw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  yaml@2.8.1:
-    resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
-    engines: {node: '>= 14.6'}
-    hasBin: true
-
   yaml@2.8.3:
     resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
     engines: {node: '>= 14.6'}
@@ -2692,44 +2784,44 @@ packages:
 
 snapshots:
 
-  '@antfu/eslint-config@7.7.3(@typescript-eslint/rule-tester@8.57.2(eslint@10.1.0)(typescript@6.0.2))(@typescript-eslint/typescript-estree@8.57.2(typescript@6.0.2))(@typescript-eslint/utils@8.57.2(eslint@10.1.0)(typescript@6.0.2))(@vue/compiler-sfc@3.5.31)(eslint@10.1.0)(typescript@6.0.2)(vitest@4.1.1(@types/node@25.5.0)(happy-dom@20.8.8)(vite@8.0.3(@types/node@25.5.0)(yaml@2.8.3)))':
+  '@antfu/eslint-config@9.0.0(@typescript-eslint/rule-tester@8.57.2(eslint@10.5.0)(typescript@6.0.3))(@typescript-eslint/typescript-estree@8.61.0(typescript@6.0.3))(@typescript-eslint/utils@8.61.0(eslint@10.5.0)(typescript@6.0.3))(@vue/compiler-sfc@3.5.38)(eslint@10.5.0)(ts-declaration-location@1.0.7(typescript@6.0.3))(typescript@6.0.3)(vitest@4.1.9(@types/node@25.9.3)(happy-dom@20.10.4)(vite@8.0.16(@types/node@25.9.3)(yaml@2.8.3)))':
     dependencies:
       '@antfu/install-pkg': 1.1.0
-      '@clack/prompts': 1.1.0
-      '@e18e/eslint-plugin': 0.2.0(eslint@10.1.0)
-      '@eslint-community/eslint-plugin-eslint-comments': 4.7.1(eslint@10.1.0)
-      '@eslint/markdown': 7.5.1
-      '@stylistic/eslint-plugin': 5.10.0(eslint@10.1.0)
-      '@typescript-eslint/eslint-plugin': 8.57.2(@typescript-eslint/parser@8.57.2(eslint@10.1.0)(typescript@6.0.2))(eslint@10.1.0)(typescript@6.0.2)
-      '@typescript-eslint/parser': 8.57.2(eslint@10.1.0)(typescript@6.0.2)
-      '@vitest/eslint-plugin': 1.6.13(@typescript-eslint/eslint-plugin@8.57.2(@typescript-eslint/parser@8.57.2(eslint@10.1.0)(typescript@6.0.2))(eslint@10.1.0)(typescript@6.0.2))(eslint@10.1.0)(typescript@6.0.2)(vitest@4.1.1(@types/node@25.5.0)(happy-dom@20.8.8)(vite@8.0.3(@types/node@25.5.0)(yaml@2.8.3)))
+      '@clack/prompts': 1.5.1
+      '@e18e/eslint-plugin': 0.4.1(eslint@10.5.0)
+      '@eslint-community/eslint-plugin-eslint-comments': 4.7.1(eslint@10.5.0)
+      '@eslint/markdown': 8.0.2
+      '@stylistic/eslint-plugin': 5.10.0(eslint@10.5.0)
+      '@typescript-eslint/eslint-plugin': 8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.61.0(eslint@10.5.0)(typescript@6.0.3)
+      '@vitest/eslint-plugin': 1.6.20(@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)(typescript@6.0.3)(vitest@4.1.9(@types/node@25.9.3)(happy-dom@20.10.4)(vite@8.0.16(@types/node@25.9.3)(yaml@2.8.3)))
       ansis: 4.2.0
       cac: 7.0.0
-      eslint: 10.1.0
-      eslint-config-flat-gitignore: 2.3.0(eslint@10.1.0)
-      eslint-flat-config-utils: 3.0.2
-      eslint-merge-processors: 2.0.0(eslint@10.1.0)
-      eslint-plugin-antfu: 3.2.2(eslint@10.1.0)
-      eslint-plugin-command: 3.5.2(@typescript-eslint/rule-tester@8.57.2(eslint@10.1.0)(typescript@6.0.2))(@typescript-eslint/typescript-estree@8.57.2(typescript@6.0.2))(@typescript-eslint/utils@8.57.2(eslint@10.1.0)(typescript@6.0.2))(eslint@10.1.0)
-      eslint-plugin-import-lite: 0.5.2(eslint@10.1.0)
-      eslint-plugin-jsdoc: 62.8.0(eslint@10.1.0)
-      eslint-plugin-jsonc: 3.1.2(eslint@10.1.0)
-      eslint-plugin-n: 17.24.0(eslint@10.1.0)(typescript@6.0.2)
-      eslint-plugin-no-only-tests: 3.3.0
-      eslint-plugin-perfectionist: 5.7.0(eslint@10.1.0)(typescript@6.0.2)
-      eslint-plugin-pnpm: 1.6.0(eslint@10.1.0)
-      eslint-plugin-regexp: 3.1.0(eslint@10.1.0)
-      eslint-plugin-toml: 1.3.1(eslint@10.1.0)
-      eslint-plugin-unicorn: 63.0.0(eslint@10.1.0)
-      eslint-plugin-unused-imports: 4.4.1(@typescript-eslint/eslint-plugin@8.57.2(@typescript-eslint/parser@8.57.2(eslint@10.1.0)(typescript@6.0.2))(eslint@10.1.0)(typescript@6.0.2))(eslint@10.1.0)
-      eslint-plugin-vue: 10.8.0(@stylistic/eslint-plugin@5.10.0(eslint@10.1.0))(@typescript-eslint/parser@8.57.2(eslint@10.1.0)(typescript@6.0.2))(eslint@10.1.0)(vue-eslint-parser@10.4.0(eslint@10.1.0))
-      eslint-plugin-yml: 3.3.1(eslint@10.1.0)
-      eslint-processor-vue-blocks: 2.0.0(@vue/compiler-sfc@3.5.31)(eslint@10.1.0)
-      globals: 17.4.0
+      eslint: 10.5.0
+      eslint-config-flat-gitignore: 2.3.0(eslint@10.5.0)
+      eslint-flat-config-utils: 3.2.0
+      eslint-merge-processors: 2.0.0(eslint@10.5.0)
+      eslint-plugin-antfu: 3.2.3(eslint@10.5.0)
+      eslint-plugin-command: 3.5.2(@typescript-eslint/rule-tester@8.57.2(eslint@10.5.0)(typescript@6.0.3))(@typescript-eslint/typescript-estree@8.61.0(typescript@6.0.3))(@typescript-eslint/utils@8.61.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)
+      eslint-plugin-import-lite: 0.6.0(eslint@10.5.0)
+      eslint-plugin-jsdoc: 62.9.0(eslint@10.5.0)
+      eslint-plugin-jsonc: 3.1.2(eslint@10.5.0)
+      eslint-plugin-n: 18.1.0(eslint@10.5.0)(ts-declaration-location@1.0.7(typescript@6.0.3))(typescript@6.0.3)
+      eslint-plugin-no-only-tests: 3.4.0
+      eslint-plugin-perfectionist: 5.9.0(eslint@10.5.0)(typescript@6.0.3)
+      eslint-plugin-pnpm: 1.6.0(eslint@10.5.0)
+      eslint-plugin-regexp: 3.1.0(eslint@10.5.0)
+      eslint-plugin-toml: 1.3.1(eslint@10.5.0)
+      eslint-plugin-unicorn: 64.0.0(eslint@10.5.0)
+      eslint-plugin-unused-imports: 4.4.1(@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)
+      eslint-plugin-vue: 10.9.2(@stylistic/eslint-plugin@5.10.0(eslint@10.5.0))(@typescript-eslint/parser@8.61.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)(vue-eslint-parser@10.4.0(eslint@10.5.0))
+      eslint-plugin-yml: 3.4.0(eslint@10.5.0)
+      eslint-processor-vue-blocks: 2.0.0(@vue/compiler-sfc@3.5.38)(eslint@10.5.0)
+      globals: 17.6.0
       local-pkg: 1.1.2
       parse-gitignore: 2.0.0
       toml-eslint-parser: 1.0.3
-      vue-eslint-parser: 10.4.0(eslint@10.1.0)
+      vue-eslint-parser: 10.4.0(eslint@10.5.0)
       yaml-eslint-parser: 2.0.0
     transitivePeerDependencies:
       - '@eslint/json'
@@ -2739,54 +2831,73 @@ snapshots:
       - '@vue/compiler-sfc'
       - oxlint
       - supports-color
+      - ts-declaration-location
       - typescript
       - vitest
 
   '@antfu/install-pkg@1.1.0':
     dependencies:
       package-manager-detector: 1.3.0
-      tinyexec: 1.0.1
+      tinyexec: 1.0.4
 
   '@babel/helper-string-parser@7.27.1': {}
 
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
 
   '@babel/types@7.29.0':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@clack/core@1.1.0':
+  '@babel/types@7.29.7':
     dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@clack/core@1.4.1':
+    dependencies:
+      fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
-  '@clack/prompts@1.1.0':
+  '@clack/prompts@1.5.1':
     dependencies:
-      '@clack/core': 1.1.0
+      '@clack/core': 1.4.1
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
-  '@e18e/eslint-plugin@0.2.0(eslint@10.1.0)':
+  '@e18e/eslint-plugin@0.4.1(eslint@10.5.0)':
     dependencies:
-      eslint-plugin-depend: 1.5.0(eslint@10.1.0)
+      empathic: 2.0.0
+      module-replacements: 3.0.0-beta.8
+      semver: 7.7.4
     optionalDependencies:
-      eslint: 10.1.0
+      eslint: 10.5.0
 
-  '@emnapi/core@1.9.1':
+  '@emnapi/core@1.10.0':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.0
+      '@emnapi/wasi-threads': 1.2.1
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.9.1':
+  '@emnapi/runtime@1.10.0':
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/wasi-threads@1.2.0':
+  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -2799,78 +2910,85 @@ snapshots:
       esquery: 1.7.0
       jsdoc-type-pratt-parser: 7.1.1
 
+  '@es-joy/jsdoccomment@0.86.0':
+    dependencies:
+      '@types/estree': 1.0.8
+      '@typescript-eslint/types': 8.61.0
+      comment-parser: 1.4.6
+      esquery: 1.7.0
+      jsdoc-type-pratt-parser: 7.2.0
+
   '@es-joy/resolve.exports@1.2.0': {}
 
-  '@eslint-community/eslint-plugin-eslint-comments@4.7.1(eslint@10.1.0)':
+  '@eslint-community/eslint-plugin-eslint-comments@4.7.1(eslint@10.5.0)':
     dependencies:
       escape-string-regexp: 4.0.0
-      eslint: 10.1.0
+      eslint: 10.5.0
       ignore: 7.0.5
 
-  '@eslint-community/eslint-utils@4.9.0(eslint@10.1.0)':
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.5.0)':
     dependencies:
-      eslint: 10.1.0
+      eslint: 10.5.0
       eslint-visitor-keys: 3.4.3
-
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.1.0)':
-    dependencies:
-      eslint: 10.1.0
-      eslint-visitor-keys: 3.4.3
-
-  '@eslint-community/regexpp@4.12.1': {}
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/compat@2.0.3(eslint@10.1.0)':
+  '@eslint/compat@2.0.3(eslint@10.5.0)':
     dependencies:
       '@eslint/core': 1.1.1
     optionalDependencies:
-      eslint: 10.1.0
+      eslint: 10.5.0
 
-  '@eslint/config-array@0.23.3':
+  '@eslint/config-array@0.23.5':
     dependencies:
-      '@eslint/object-schema': 3.0.3
+      '@eslint/object-schema': 3.0.5
       debug: 4.4.3
       minimatch: 10.2.4
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/config-helpers@0.5.3':
+  '@eslint/config-helpers@0.5.5':
     dependencies:
-      '@eslint/core': 1.1.1
+      '@eslint/core': 1.2.1
 
-  '@eslint/core@0.17.0':
+  '@eslint/config-helpers@0.6.0':
     dependencies:
-      '@types/json-schema': 7.0.15
+      '@eslint/core': 1.2.1
 
   '@eslint/core@1.1.1':
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/markdown@7.5.1':
+  '@eslint/core@1.2.1':
     dependencies:
-      '@eslint/core': 0.17.0
-      '@eslint/plugin-kit': 0.4.1
+      '@types/json-schema': 7.0.15
+
+  '@eslint/markdown@8.0.2':
+    dependencies:
+      '@eslint/core': 1.2.1
+      '@eslint/plugin-kit': 0.7.2
       github-slugger: 2.0.0
       mdast-util-from-markdown: 2.0.2
       mdast-util-frontmatter: 2.0.1
       mdast-util-gfm: 3.1.0
+      mdast-util-math: 3.0.0
       micromark-extension-frontmatter: 2.0.0
       micromark-extension-gfm: 3.0.0
+      micromark-extension-math: 3.1.0
       micromark-util-normalize-identifier: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/object-schema@3.0.3': {}
-
-  '@eslint/plugin-kit@0.4.1':
-    dependencies:
-      '@eslint/core': 0.17.0
-      levn: 0.4.1
+  '@eslint/object-schema@3.0.5': {}
 
   '@eslint/plugin-kit@0.6.1':
     dependencies:
       '@eslint/core': 1.1.1
+      levn: 0.4.1
+
+  '@eslint/plugin-kit@0.7.2':
+    dependencies:
+      '@eslint/core': 1.2.1
       levn: 0.4.1
 
   '@humanfs/core@0.19.1': {}
@@ -2914,24 +3032,24 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@microsoft/api-extractor-model@7.33.4(@types/node@25.5.0)':
+  '@microsoft/api-extractor-model@7.33.4(@types/node@25.9.3)':
     dependencies:
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
-      '@rushstack/node-core-library': 5.20.3(@types/node@25.5.0)
+      '@rushstack/node-core-library': 5.20.3(@types/node@25.9.3)
     transitivePeerDependencies:
       - '@types/node'
     optional: true
 
-  '@microsoft/api-extractor@7.57.7(@types/node@25.5.0)':
+  '@microsoft/api-extractor@7.57.7(@types/node@25.9.3)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.33.4(@types/node@25.5.0)
+      '@microsoft/api-extractor-model': 7.33.4(@types/node@25.9.3)
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
-      '@rushstack/node-core-library': 5.20.3(@types/node@25.5.0)
+      '@rushstack/node-core-library': 5.20.3(@types/node@25.9.3)
       '@rushstack/rig-package': 0.7.2
-      '@rushstack/terminal': 0.22.3(@types/node@25.5.0)
-      '@rushstack/ts-command-line': 5.3.3(@types/node@25.5.0)
+      '@rushstack/terminal': 0.22.3(@types/node@25.9.3)
+      '@rushstack/ts-command-line': 5.3.3(@types/node@25.9.3)
       diff: 8.0.4
       lodash: 4.17.23
       minimatch: 10.2.3
@@ -2954,96 +3072,96 @@ snapshots:
   '@microsoft/tsdoc@0.16.0':
     optional: true
 
-  '@nabla/vite-plugin-eslint@3.0.1(eslint@10.1.0)(vite@8.0.3(@types/node@25.5.0)(yaml@2.8.3))':
+  '@nabla/vite-plugin-eslint@3.0.1(eslint@10.5.0)(vite@8.0.16(@types/node@25.9.3)(yaml@2.8.3))':
     dependencies:
       '@types/eslint': 9.6.1
       chalk: 4.1.2
       debug: 4.4.3
-      eslint: 10.1.0
-      vite: 8.0.3(@types/node@25.5.0)(yaml@2.8.3)
+      eslint: 10.5.0
+      vite: 8.0.16(@types/node@25.9.3)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@napi-rs/wasm-runtime@1.1.1':
+  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@emnapi/core': 1.9.1
-      '@emnapi/runtime': 1.9.1
-      '@tybys/wasm-util': 0.10.1
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.2
     optional: true
 
   '@one-ini/wasm@0.1.1': {}
 
   '@ota-meshi/ast-token-store@0.3.0': {}
 
-  '@oxc-project/types@0.122.0': {}
+  '@oxc-project/types@0.133.0': {}
 
-  '@pinia/testing@1.0.3(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))':
+  '@pinia/testing@1.0.3(pinia@3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3)))':
     dependencies:
-      pinia: 3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2))
+      pinia: 3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3))
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
   '@pkgr/core@0.2.9': {}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.12':
+  '@rolldown/binding-android-arm64@1.0.3':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
+  '@rolldown/binding-darwin-arm64@1.0.3':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.12':
+  '@rolldown/binding-darwin-x64@1.0.3':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
+  '@rolldown/binding-freebsd-x64@1.0.3':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
+  '@rolldown/binding-linux-arm64-musl@1.0.3':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
+  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
+  '@rolldown/binding-linux-s390x-gnu@1.0.3':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
+  '@rolldown/binding-linux-x64-gnu@1.0.3':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
+  '@rolldown/binding-linux-x64-musl@1.0.3':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
+  '@rolldown/binding-openharmony-arm64@1.0.3':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12':
+  '@rolldown/binding-wasm32-wasi@1.0.3':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.1
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
+  '@rolldown/binding-win32-arm64-msvc@1.0.3':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.12':
+  '@rolldown/binding-win32-x64-msvc@1.0.3':
     optional: true
 
-  '@rolldown/pluginutils@1.0.0-rc.12': {}
-
-  '@rolldown/pluginutils@1.0.0-rc.2': {}
+  '@rolldown/pluginutils@1.0.1': {}
 
   '@rollup/pluginutils@5.3.0':
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
-  '@rushstack/node-core-library@5.20.3(@types/node@25.5.0)':
+  '@rushstack/node-core-library@5.20.3(@types/node@25.9.3)':
     dependencies:
       ajv: 8.18.0
       ajv-draft-04: 1.0.0(ajv@8.18.0)
@@ -3054,12 +3172,12 @@ snapshots:
       resolve: 1.22.8
       semver: 7.5.4
     optionalDependencies:
-      '@types/node': 25.5.0
+      '@types/node': 25.9.3
     optional: true
 
-  '@rushstack/problem-matcher@0.2.1(@types/node@25.5.0)':
+  '@rushstack/problem-matcher@0.2.1(@types/node@25.9.3)':
     optionalDependencies:
-      '@types/node': 25.5.0
+      '@types/node': 25.9.3
     optional: true
 
   '@rushstack/rig-package@0.7.2':
@@ -3068,18 +3186,18 @@ snapshots:
       strip-json-comments: 3.1.1
     optional: true
 
-  '@rushstack/terminal@0.22.3(@types/node@25.5.0)':
+  '@rushstack/terminal@0.22.3(@types/node@25.9.3)':
     dependencies:
-      '@rushstack/node-core-library': 5.20.3(@types/node@25.5.0)
-      '@rushstack/problem-matcher': 0.2.1(@types/node@25.5.0)
+      '@rushstack/node-core-library': 5.20.3(@types/node@25.9.3)
+      '@rushstack/problem-matcher': 0.2.1(@types/node@25.9.3)
       supports-color: 8.1.1
     optionalDependencies:
-      '@types/node': 25.5.0
+      '@types/node': 25.9.3
     optional: true
 
-  '@rushstack/ts-command-line@5.3.3(@types/node@25.5.0)':
+  '@rushstack/ts-command-line@5.3.3(@types/node@25.9.3)':
     dependencies:
-      '@rushstack/terminal': 0.22.3(@types/node@25.5.0)
+      '@rushstack/terminal': 0.22.3(@types/node@25.9.3)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -3091,17 +3209,17 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@stylistic/eslint-plugin@5.10.0(eslint@10.1.0)':
+  '@stylistic/eslint-plugin@5.10.0(eslint@10.5.0)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.1.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0)
       '@typescript-eslint/types': 8.57.2
-      eslint: 10.1.0
+      eslint: 10.5.0
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
       estraverse: 5.3.0
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
-  '@tybys/wasm-util@0.10.1':
+  '@tybys/wasm-util@0.10.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -3128,7 +3246,13 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/json-schema@7.0.15': {}
+
+  '@types/katex@0.16.8': {}
 
   '@types/mdast@4.0.4':
     dependencies:
@@ -3140,6 +3264,10 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
+  '@types/node@25.9.3':
+    dependencies:
+      undici-types: 7.24.6
+
   '@types/unist@3.0.3': {}
 
   '@types/web-bluetooth@0.0.21': {}
@@ -3150,50 +3278,71 @@ snapshots:
     dependencies:
       '@types/node': 25.5.0
 
-  '@typescript-eslint/eslint-plugin@8.57.2(@typescript-eslint/parser@8.57.2(eslint@10.1.0)(typescript@6.0.2))(eslint@10.1.0)(typescript@6.0.2)':
+  '@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.57.2(eslint@10.1.0)(typescript@6.0.2)
-      '@typescript-eslint/scope-manager': 8.57.2
-      '@typescript-eslint/type-utils': 8.57.2(eslint@10.1.0)(typescript@6.0.2)
-      '@typescript-eslint/utils': 8.57.2(eslint@10.1.0)(typescript@6.0.2)
-      '@typescript-eslint/visitor-keys': 8.57.2
-      eslint: 10.1.0
+      '@typescript-eslint/parser': 8.61.0(eslint@10.5.0)(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 8.61.0
+      '@typescript-eslint/type-utils': 8.61.0(eslint@10.5.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.61.0(eslint@10.5.0)(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.61.0
+      eslint: 10.5.0
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@6.0.2)
-      typescript: 6.0.2
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.57.2(eslint@10.1.0)(typescript@6.0.2)':
+  '@typescript-eslint/parser@8.57.2(eslint@10.5.0)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.57.2
       '@typescript-eslint/types': 8.57.2
-      '@typescript-eslint/typescript-estree': 8.57.2(typescript@6.0.2)
+      '@typescript-eslint/typescript-estree': 8.57.2(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.57.2
       debug: 4.4.3
-      eslint: 10.1.0
-      typescript: 6.0.2
+      eslint: 10.5.0
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.57.2(typescript@6.0.2)':
+  '@typescript-eslint/parser@8.61.0(eslint@10.5.0)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.57.2(typescript@6.0.2)
-      '@typescript-eslint/types': 8.57.2
+      '@typescript-eslint/scope-manager': 8.61.0
+      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/typescript-estree': 8.61.0(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.61.0
       debug: 4.4.3
-      typescript: 6.0.2
+      eslint: 10.5.0
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/rule-tester@8.57.2(eslint@10.1.0)(typescript@6.0.2)':
+  '@typescript-eslint/project-service@8.57.2(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/parser': 8.57.2(eslint@10.1.0)(typescript@6.0.2)
-      '@typescript-eslint/typescript-estree': 8.57.2(typescript@6.0.2)
-      '@typescript-eslint/utils': 8.57.2(eslint@10.1.0)(typescript@6.0.2)
+      '@typescript-eslint/tsconfig-utils': 8.61.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.61.0
+      debug: 4.4.3
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.61.0(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.61.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.61.0
+      debug: 4.4.3
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/rule-tester@8.57.2(eslint@10.5.0)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/parser': 8.57.2(eslint@10.5.0)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.57.2(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.57.2(eslint@10.5.0)(typescript@6.0.3)
       ajv: 6.14.0
-      eslint: 10.1.0
+      eslint: 10.5.0
       json-stable-stringify-without-jsonify: 1.0.1
       lodash.merge: 4.6.2
       semver: 7.7.4
@@ -3206,47 +3355,84 @@ snapshots:
       '@typescript-eslint/types': 8.57.2
       '@typescript-eslint/visitor-keys': 8.57.2
 
-  '@typescript-eslint/tsconfig-utils@8.57.2(typescript@6.0.2)':
+  '@typescript-eslint/scope-manager@8.61.0':
     dependencies:
-      typescript: 6.0.2
+      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/visitor-keys': 8.61.0
 
-  '@typescript-eslint/type-utils@8.57.2(eslint@10.1.0)(typescript@6.0.2)':
+  '@typescript-eslint/tsconfig-utils@8.57.2(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/types': 8.57.2
-      '@typescript-eslint/typescript-estree': 8.57.2(typescript@6.0.2)
-      '@typescript-eslint/utils': 8.57.2(eslint@10.1.0)(typescript@6.0.2)
+      typescript: 6.0.3
+
+  '@typescript-eslint/tsconfig-utils@8.61.0(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+
+  '@typescript-eslint/type-utils@8.61.0(eslint@10.5.0)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/typescript-estree': 8.61.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.61.0(eslint@10.5.0)(typescript@6.0.3)
       debug: 4.4.3
-      eslint: 10.1.0
-      ts-api-utils: 2.5.0(typescript@6.0.2)
-      typescript: 6.0.2
+      eslint: 10.5.0
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.57.2': {}
 
-  '@typescript-eslint/typescript-estree@8.57.2(typescript@6.0.2)':
+  '@typescript-eslint/types@8.61.0': {}
+
+  '@typescript-eslint/typescript-estree@8.57.2(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.57.2(typescript@6.0.2)
-      '@typescript-eslint/tsconfig-utils': 8.57.2(typescript@6.0.2)
+      '@typescript-eslint/project-service': 8.57.2(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.57.2(typescript@6.0.3)
       '@typescript-eslint/types': 8.57.2
       '@typescript-eslint/visitor-keys': 8.57.2
       debug: 4.4.3
       minimatch: 10.2.4
       semver: 7.7.4
-      tinyglobby: 0.2.15
-      ts-api-utils: 2.5.0(typescript@6.0.2)
-      typescript: 6.0.2
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.57.2(eslint@10.1.0)(typescript@6.0.2)':
+  '@typescript-eslint/typescript-estree@8.61.0(typescript@6.0.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.1.0)
+      '@typescript-eslint/project-service': 8.61.0(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.61.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/visitor-keys': 8.61.0
+      debug: 4.4.3
+      minimatch: 10.2.4
+      semver: 7.7.4
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.57.2(eslint@10.5.0)(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0)
       '@typescript-eslint/scope-manager': 8.57.2
       '@typescript-eslint/types': 8.57.2
-      '@typescript-eslint/typescript-estree': 8.57.2(typescript@6.0.2)
-      eslint: 10.1.0
-      typescript: 6.0.2
+      '@typescript-eslint/typescript-estree': 8.57.2(typescript@6.0.3)
+      eslint: 10.5.0
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.61.0(eslint@10.5.0)(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0)
+      '@typescript-eslint/scope-manager': 8.61.0
+      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/typescript-estree': 8.61.0(typescript@6.0.3)
+      eslint: 10.5.0
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -3255,62 +3441,67 @@ snapshots:
       '@typescript-eslint/types': 8.57.2
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-vue@6.0.5(vite@8.0.3(@types/node@25.5.0)(yaml@2.8.3))(vue@3.5.31(typescript@6.0.2))':
+  '@typescript-eslint/visitor-keys@8.61.0':
     dependencies:
-      '@rolldown/pluginutils': 1.0.0-rc.2
-      vite: 8.0.3(@types/node@25.5.0)(yaml@2.8.3)
-      vue: 3.5.31(typescript@6.0.2)
+      '@typescript-eslint/types': 8.61.0
+      eslint-visitor-keys: 5.0.1
 
-  '@vitest/eslint-plugin@1.6.13(@typescript-eslint/eslint-plugin@8.57.2(@typescript-eslint/parser@8.57.2(eslint@10.1.0)(typescript@6.0.2))(eslint@10.1.0)(typescript@6.0.2))(eslint@10.1.0)(typescript@6.0.2)(vitest@4.1.1(@types/node@25.5.0)(happy-dom@20.8.8)(vite@8.0.3(@types/node@25.5.0)(yaml@2.8.3)))':
+  '@vitejs/plugin-vue@6.0.7(vite@8.0.16(@types/node@25.9.3)(yaml@2.8.3))(vue@3.5.38(typescript@6.0.3))':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.57.2
-      '@typescript-eslint/utils': 8.57.2(eslint@10.1.0)(typescript@6.0.2)
-      eslint: 10.1.0
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.0.16(@types/node@25.9.3)(yaml@2.8.3)
+      vue: 3.5.38(typescript@6.0.3)
+
+  '@vitest/eslint-plugin@1.6.20(@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)(typescript@6.0.3)(vitest@4.1.9(@types/node@25.9.3)(happy-dom@20.10.4)(vite@8.0.16(@types/node@25.9.3)(yaml@2.8.3)))':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.61.0
+      '@typescript-eslint/utils': 8.61.0(eslint@10.5.0)(typescript@6.0.3)
+      eslint: 10.5.0
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.57.2(@typescript-eslint/parser@8.57.2(eslint@10.1.0)(typescript@6.0.2))(eslint@10.1.0)(typescript@6.0.2)
-      typescript: 6.0.2
-      vitest: 4.1.1(@types/node@25.5.0)(happy-dom@20.8.8)(vite@8.0.3(@types/node@25.5.0)(yaml@2.8.3))
+      '@typescript-eslint/eslint-plugin': 8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)(typescript@6.0.3)
+      typescript: 6.0.3
+      vitest: 4.1.9(@types/node@25.9.3)(happy-dom@20.10.4)(vite@8.0.16(@types/node@25.9.3)(yaml@2.8.3))
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@4.1.1':
+  '@vitest/expect@4.1.9':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.2
-      '@vitest/spy': 4.1.1
-      '@vitest/utils': 4.1.1
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.1(vite@8.0.3(@types/node@25.5.0)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.9(vite@8.0.16(@types/node@25.9.3)(yaml@2.8.3))':
     dependencies:
-      '@vitest/spy': 4.1.1
+      '@vitest/spy': 4.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.3(@types/node@25.5.0)(yaml@2.8.3)
+      vite: 8.0.16(@types/node@25.9.3)(yaml@2.8.3)
 
-  '@vitest/pretty-format@4.1.1':
+  '@vitest/pretty-format@4.1.9':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.1':
+  '@vitest/runner@4.1.9':
     dependencies:
-      '@vitest/utils': 4.1.1
+      '@vitest/utils': 4.1.9
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.1':
+  '@vitest/snapshot@4.1.9':
     dependencies:
-      '@vitest/pretty-format': 4.1.1
-      '@vitest/utils': 4.1.1
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/utils': 4.1.9
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.1': {}
+  '@vitest/spy@4.1.9': {}
 
-  '@vitest/utils@4.1.1':
+  '@vitest/utils@4.1.9':
     dependencies:
-      '@vitest/pretty-format': 4.1.1
+      '@vitest/pretty-format': 4.1.9
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -3326,25 +3517,17 @@ snapshots:
       path-browserify: 1.0.1
       vscode-uri: 3.0.8
 
-  '@volverjs/data@2.0.4(typescript@6.0.2)':
+  '@volverjs/data@2.0.5(typescript@6.0.3)':
     dependencies:
       abort-controller: 3.0.0
       ky: 1.14.3
       node-fetch: 3.3.2
-      qs: 6.14.0
-      web-streams-polyfill: 4.2.0
+      qs: 6.15.2
+      web-streams-polyfill: 4.3.0
     optionalDependencies:
-      vue: 3.5.31(typescript@6.0.2)
+      vue: 3.5.38(typescript@6.0.3)
     transitivePeerDependencies:
       - typescript
-
-  '@vue/compiler-core@3.5.30':
-    dependencies:
-      '@babel/parser': 7.29.2
-      '@vue/shared': 3.5.30
-      entities: 7.0.1
-      estree-walker: 2.0.2
-      source-map-js: 1.2.1
 
   '@vue/compiler-core@3.5.31':
     dependencies:
@@ -3354,32 +3537,40 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
-  '@vue/compiler-dom@3.5.30':
+  '@vue/compiler-core@3.5.38':
     dependencies:
-      '@vue/compiler-core': 3.5.30
-      '@vue/shared': 3.5.30
+      '@babel/parser': 7.29.7
+      '@vue/shared': 3.5.38
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
 
   '@vue/compiler-dom@3.5.31':
     dependencies:
       '@vue/compiler-core': 3.5.31
       '@vue/shared': 3.5.31
 
-  '@vue/compiler-sfc@3.5.31':
+  '@vue/compiler-dom@3.5.38':
     dependencies:
-      '@babel/parser': 7.29.2
-      '@vue/compiler-core': 3.5.31
-      '@vue/compiler-dom': 3.5.31
-      '@vue/compiler-ssr': 3.5.31
-      '@vue/shared': 3.5.31
+      '@vue/compiler-core': 3.5.38
+      '@vue/shared': 3.5.38
+
+  '@vue/compiler-sfc@3.5.38':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@vue/compiler-core': 3.5.38
+      '@vue/compiler-dom': 3.5.38
+      '@vue/compiler-ssr': 3.5.38
+      '@vue/shared': 3.5.38
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.8
+      postcss: 8.5.15
       source-map-js: 1.2.1
 
-  '@vue/compiler-ssr@3.5.31':
+  '@vue/compiler-ssr@3.5.38':
     dependencies:
-      '@vue/compiler-dom': 3.5.31
-      '@vue/shared': 3.5.31
+      '@vue/compiler-dom': 3.5.38
+      '@vue/shared': 3.5.38
 
   '@vue/devtools-api@7.7.9':
     dependencies:
@@ -3399,59 +3590,63 @@ snapshots:
     dependencies:
       rfdc: 1.4.1
 
-  '@vue/language-core@3.2.6':
+  '@vue/language-core@3.3.5':
     dependencies:
       '@volar/language-core': 2.4.28
-      '@vue/compiler-dom': 3.5.30
-      '@vue/shared': 3.5.30
-      alien-signals: 3.0.0
+      '@vue/compiler-dom': 3.5.31
+      '@vue/shared': 3.5.38
+      alien-signals: 3.2.1
       muggle-string: 0.4.1
       path-browserify: 1.0.1
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
-  '@vue/reactivity@3.5.31':
+  '@vue/reactivity@3.5.38':
     dependencies:
-      '@vue/shared': 3.5.31
+      '@vue/shared': 3.5.38
 
-  '@vue/runtime-core@3.5.31':
+  '@vue/runtime-core@3.5.38':
     dependencies:
-      '@vue/reactivity': 3.5.31
-      '@vue/shared': 3.5.31
+      '@vue/reactivity': 3.5.38
+      '@vue/shared': 3.5.38
 
-  '@vue/runtime-dom@3.5.31':
+  '@vue/runtime-dom@3.5.38':
     dependencies:
-      '@vue/reactivity': 3.5.31
-      '@vue/runtime-core': 3.5.31
-      '@vue/shared': 3.5.31
+      '@vue/reactivity': 3.5.38
+      '@vue/runtime-core': 3.5.38
+      '@vue/shared': 3.5.38
       csstype: 3.2.3
 
-  '@vue/server-renderer@3.5.31(vue@3.5.31(typescript@6.0.2))':
+  '@vue/server-renderer@3.5.38(vue@3.5.38(typescript@6.0.3))':
     dependencies:
-      '@vue/compiler-ssr': 3.5.31
-      '@vue/shared': 3.5.31
-      vue: 3.5.31(typescript@6.0.2)
-
-  '@vue/shared@3.5.30': {}
+      '@vue/compiler-ssr': 3.5.38
+      '@vue/shared': 3.5.38
+      vue: 3.5.38(typescript@6.0.3)
 
   '@vue/shared@3.5.31': {}
 
-  '@vue/test-utils@2.4.6':
-    dependencies:
-      js-beautify: 1.15.1
-      vue-component-type-helpers: 2.1.10
+  '@vue/shared@3.5.38': {}
 
-  '@vueuse/core@14.2.1(vue@3.5.31(typescript@6.0.2))':
+  '@vue/test-utils@2.4.11(@vue/compiler-dom@3.5.38)(@vue/server-renderer@3.5.38(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3))':
+    dependencies:
+      '@vue/compiler-dom': 3.5.38
+      js-beautify: 1.15.1
+      vue: 3.5.38(typescript@6.0.3)
+      vue-component-type-helpers: 3.3.5
+    optionalDependencies:
+      '@vue/server-renderer': 3.5.38(vue@3.5.38(typescript@6.0.3))
+
+  '@vueuse/core@14.3.0(vue@3.5.38(typescript@6.0.3))':
     dependencies:
       '@types/web-bluetooth': 0.0.21
-      '@vueuse/metadata': 14.2.1
-      '@vueuse/shared': 14.2.1(vue@3.5.31(typescript@6.0.2))
-      vue: 3.5.31(typescript@6.0.2)
+      '@vueuse/metadata': 14.3.0
+      '@vueuse/shared': 14.3.0(vue@3.5.38(typescript@6.0.3))
+      vue: 3.5.38(typescript@6.0.3)
 
-  '@vueuse/metadata@14.2.1': {}
+  '@vueuse/metadata@14.3.0': {}
 
-  '@vueuse/shared@14.2.1(vue@3.5.31(typescript@6.0.2))':
+  '@vueuse/shared@14.3.0(vue@3.5.38(typescript@6.0.3))':
     dependencies:
-      vue: 3.5.31(typescript@6.0.2)
+      vue: 3.5.38(typescript@6.0.3)
 
   abbrev@2.0.0: {}
 
@@ -3459,15 +3654,9 @@ snapshots:
     dependencies:
       event-target-shim: 5.0.1
 
-  acorn-jsx@5.3.2(acorn@8.15.0):
-    dependencies:
-      acorn: 8.15.0
-
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
-
-  acorn@8.15.0: {}
 
   acorn@8.16.0: {}
 
@@ -3496,7 +3685,7 @@ snapshots:
       require-from-string: 2.0.2
     optional: true
 
-  alien-signals@3.0.0: {}
+  alien-signals@3.2.1: {}
 
   ansi-green@0.1.1:
     dependencies:
@@ -3562,6 +3751,10 @@ snapshots:
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
+  buffer-image-size@0.6.4:
+    dependencies:
+      '@types/node': 25.5.0
+
   builtin-modules@5.0.0: {}
 
   cac@7.0.0: {}
@@ -3609,9 +3802,11 @@ snapshots:
 
   commander@10.0.1: {}
 
-  comment-parser@1.4.1: {}
+  commander@8.3.0: {}
 
   comment-parser@1.4.5: {}
+
+  comment-parser@1.4.6: {}
 
   compare-versions@6.1.1: {}
 
@@ -3707,7 +3902,7 @@ snapshots:
       '@one-ini/wasm': 0.1.1
       commander: 10.0.1
       minimatch: 9.0.1
-      semver: 7.7.1
+      semver: 7.7.4
 
   electron-to-chromium@1.5.323: {}
 
@@ -3742,70 +3937,63 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-compat-utils@0.5.1(eslint@10.1.0):
+  eslint-compat-utils@0.5.1(eslint@10.5.0):
     dependencies:
-      eslint: 10.1.0
-      semver: 7.7.2
+      eslint: 10.5.0
+      semver: 7.7.4
 
-  eslint-config-flat-gitignore@2.3.0(eslint@10.1.0):
+  eslint-config-flat-gitignore@2.3.0(eslint@10.5.0):
     dependencies:
-      '@eslint/compat': 2.0.3(eslint@10.1.0)
-      eslint: 10.1.0
+      '@eslint/compat': 2.0.3(eslint@10.5.0)
+      eslint: 10.5.0
 
-  eslint-flat-config-utils@3.0.2:
+  eslint-flat-config-utils@3.2.0:
     dependencies:
-      '@eslint/config-helpers': 0.5.3
+      '@eslint/config-helpers': 0.5.5
       pathe: 2.0.3
 
-  eslint-json-compat-utils@0.2.3(eslint@10.1.0)(jsonc-eslint-parser@3.1.0):
+  eslint-json-compat-utils@0.2.3(eslint@10.5.0)(jsonc-eslint-parser@3.1.0):
     dependencies:
-      eslint: 10.1.0
-      esquery: 1.6.0
+      eslint: 10.5.0
+      esquery: 1.7.0
       jsonc-eslint-parser: 3.1.0
 
-  eslint-merge-processors@2.0.0(eslint@10.1.0):
+  eslint-merge-processors@2.0.0(eslint@10.5.0):
     dependencies:
-      eslint: 10.1.0
+      eslint: 10.5.0
 
-  eslint-plugin-antfu@3.2.2(eslint@10.1.0):
+  eslint-plugin-antfu@3.2.3(eslint@10.5.0):
     dependencies:
-      eslint: 10.1.0
+      eslint: 10.5.0
 
-  eslint-plugin-command@3.5.2(@typescript-eslint/rule-tester@8.57.2(eslint@10.1.0)(typescript@6.0.2))(@typescript-eslint/typescript-estree@8.57.2(typescript@6.0.2))(@typescript-eslint/utils@8.57.2(eslint@10.1.0)(typescript@6.0.2))(eslint@10.1.0):
+  eslint-plugin-command@3.5.2(@typescript-eslint/rule-tester@8.57.2(eslint@10.5.0)(typescript@6.0.3))(@typescript-eslint/typescript-estree@8.61.0(typescript@6.0.3))(@typescript-eslint/utils@8.61.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0):
     dependencies:
       '@es-joy/jsdoccomment': 0.84.0
-      '@typescript-eslint/rule-tester': 8.57.2(eslint@10.1.0)(typescript@6.0.2)
-      '@typescript-eslint/typescript-estree': 8.57.2(typescript@6.0.2)
-      '@typescript-eslint/utils': 8.57.2(eslint@10.1.0)(typescript@6.0.2)
-      eslint: 10.1.0
+      '@typescript-eslint/rule-tester': 8.57.2(eslint@10.5.0)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.61.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.61.0(eslint@10.5.0)(typescript@6.0.3)
+      eslint: 10.5.0
 
-  eslint-plugin-depend@1.5.0(eslint@10.1.0):
+  eslint-plugin-es-x@7.8.0(eslint@10.5.0):
     dependencies:
-      empathic: 2.0.0
-      eslint: 10.1.0
-      module-replacements: 2.11.0
-      semver: 7.7.2
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0)
+      '@eslint-community/regexpp': 4.12.2
+      eslint: 10.5.0
+      eslint-compat-utils: 0.5.1(eslint@10.5.0)
 
-  eslint-plugin-es-x@7.8.0(eslint@10.1.0):
+  eslint-plugin-import-lite@0.6.0(eslint@10.5.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@10.1.0)
-      '@eslint-community/regexpp': 4.12.1
-      eslint: 10.1.0
-      eslint-compat-utils: 0.5.1(eslint@10.1.0)
+      eslint: 10.5.0
 
-  eslint-plugin-import-lite@0.5.2(eslint@10.1.0):
+  eslint-plugin-jsdoc@62.9.0(eslint@10.5.0):
     dependencies:
-      eslint: 10.1.0
-
-  eslint-plugin-jsdoc@62.8.0(eslint@10.1.0):
-    dependencies:
-      '@es-joy/jsdoccomment': 0.84.0
+      '@es-joy/jsdoccomment': 0.86.0
       '@es-joy/resolve.exports': 1.2.0
       are-docs-informative: 0.0.2
-      comment-parser: 1.4.5
+      comment-parser: 1.4.6
       debug: 4.4.3
       escape-string-regexp: 4.0.0
-      eslint: 10.1.0
+      eslint: 10.5.0
       espree: 11.2.0
       esquery: 1.7.0
       html-entities: 2.6.0
@@ -3817,51 +4005,51 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-jsonc@3.1.2(eslint@10.1.0):
+  eslint-plugin-jsonc@3.1.2(eslint@10.5.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@10.1.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0)
       '@eslint/core': 1.1.1
       '@eslint/plugin-kit': 0.6.1
       '@ota-meshi/ast-token-store': 0.3.0
       diff-sequences: 29.6.3
-      eslint: 10.1.0
-      eslint-json-compat-utils: 0.2.3(eslint@10.1.0)(jsonc-eslint-parser@3.1.0)
+      eslint: 10.5.0
+      eslint-json-compat-utils: 0.2.3(eslint@10.5.0)(jsonc-eslint-parser@3.1.0)
       jsonc-eslint-parser: 3.1.0
       natural-compare: 1.4.0
       synckit: 0.11.12
     transitivePeerDependencies:
       - '@eslint/json'
 
-  eslint-plugin-n@17.24.0(eslint@10.1.0)(typescript@6.0.2):
+  eslint-plugin-n@18.1.0(eslint@10.5.0)(ts-declaration-location@1.0.7(typescript@6.0.3))(typescript@6.0.3):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@10.1.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0)
       enhanced-resolve: 5.17.1
-      eslint: 10.1.0
-      eslint-plugin-es-x: 7.8.0(eslint@10.1.0)
+      eslint: 10.5.0
+      eslint-plugin-es-x: 7.8.0(eslint@10.5.0)
       get-tsconfig: 4.10.0
       globals: 15.15.0
       globrex: 0.1.2
       ignore: 5.3.2
-      semver: 7.7.2
-      ts-declaration-location: 1.0.7(typescript@6.0.2)
-    transitivePeerDependencies:
-      - typescript
+      semver: 7.7.4
+    optionalDependencies:
+      ts-declaration-location: 1.0.7(typescript@6.0.3)
+      typescript: 6.0.3
 
-  eslint-plugin-no-only-tests@3.3.0: {}
+  eslint-plugin-no-only-tests@3.4.0: {}
 
-  eslint-plugin-perfectionist@5.7.0(eslint@10.1.0)(typescript@6.0.2):
+  eslint-plugin-perfectionist@5.9.0(eslint@10.5.0)(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/utils': 8.57.2(eslint@10.1.0)(typescript@6.0.2)
-      eslint: 10.1.0
+      '@typescript-eslint/utils': 8.61.0(eslint@10.5.0)(typescript@6.0.3)
+      eslint: 10.5.0
       natural-orderby: 5.0.0
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint-plugin-pnpm@1.6.0(eslint@10.1.0):
+  eslint-plugin-pnpm@1.6.0(eslint@10.5.0):
     dependencies:
       empathic: 2.0.0
-      eslint: 10.1.0
+      eslint: 10.5.0
       jsonc-eslint-parser: 3.1.0
       pathe: 2.0.3
       pnpm-workspace-yaml: 1.6.0
@@ -3869,39 +4057,39 @@ snapshots:
       yaml: 2.8.3
       yaml-eslint-parser: 2.0.0
 
-  eslint-plugin-regexp@3.1.0(eslint@10.1.0):
+  eslint-plugin-regexp@3.1.0(eslint@10.5.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@10.1.0)
-      '@eslint-community/regexpp': 4.12.1
-      comment-parser: 1.4.1
-      eslint: 10.1.0
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0)
+      '@eslint-community/regexpp': 4.12.2
+      comment-parser: 1.4.5
+      eslint: 10.5.0
       jsdoc-type-pratt-parser: 7.1.1
       refa: 0.12.1
       regexp-ast-analysis: 0.7.1
       scslre: 0.3.0
 
-  eslint-plugin-toml@1.3.1(eslint@10.1.0):
+  eslint-plugin-toml@1.3.1(eslint@10.5.0):
     dependencies:
       '@eslint/core': 1.1.1
       '@eslint/plugin-kit': 0.6.1
       '@ota-meshi/ast-token-store': 0.3.0
       debug: 4.4.3
-      eslint: 10.1.0
+      eslint: 10.5.0
       toml-eslint-parser: 1.0.3
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-unicorn@63.0.0(eslint@10.1.0):
+  eslint-plugin-unicorn@64.0.0(eslint@10.5.0):
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
-      '@eslint-community/eslint-utils': 4.9.0(eslint@10.1.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0)
       change-case: 5.4.4
       ci-info: 4.4.0
       clean-regexp: 1.0.0
       core-js-compat: 3.49.0
-      eslint: 10.1.0
+      eslint: 10.5.0
       find-up-simple: 1.0.1
-      globals: 16.4.0
+      globals: 17.4.0
       indent-string: 5.0.0
       is-builtin-module: 5.0.0
       jsesc: 3.1.0
@@ -3911,49 +4099,41 @@ snapshots:
       semver: 7.7.4
       strip-indent: 4.1.1
 
-  eslint-plugin-unused-imports@4.4.1(@typescript-eslint/eslint-plugin@8.57.2(@typescript-eslint/parser@8.57.2(eslint@10.1.0)(typescript@6.0.2))(eslint@10.1.0)(typescript@6.0.2))(eslint@10.1.0):
+  eslint-plugin-unused-imports@4.4.1(@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0):
     dependencies:
-      eslint: 10.1.0
+      eslint: 10.5.0
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.57.2(@typescript-eslint/parser@8.57.2(eslint@10.1.0)(typescript@6.0.2))(eslint@10.1.0)(typescript@6.0.2)
+      '@typescript-eslint/eslint-plugin': 8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)(typescript@6.0.3)
 
-  eslint-plugin-vue@10.8.0(@stylistic/eslint-plugin@5.10.0(eslint@10.1.0))(@typescript-eslint/parser@8.57.2(eslint@10.1.0)(typescript@6.0.2))(eslint@10.1.0)(vue-eslint-parser@10.4.0(eslint@10.1.0)):
+  eslint-plugin-vue@10.9.2(@stylistic/eslint-plugin@5.10.0(eslint@10.5.0))(@typescript-eslint/parser@8.61.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)(vue-eslint-parser@10.4.0(eslint@10.5.0)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@10.1.0)
-      eslint: 10.1.0
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0)
+      eslint: 10.5.0
       natural-compare: 1.4.0
       nth-check: 2.1.1
       postcss-selector-parser: 7.1.1
-      semver: 7.7.2
-      vue-eslint-parser: 10.4.0(eslint@10.1.0)
+      semver: 7.7.4
+      vue-eslint-parser: 10.4.0(eslint@10.5.0)
       xml-name-validator: 4.0.0
     optionalDependencies:
-      '@stylistic/eslint-plugin': 5.10.0(eslint@10.1.0)
-      '@typescript-eslint/parser': 8.57.2(eslint@10.1.0)(typescript@6.0.2)
+      '@stylistic/eslint-plugin': 5.10.0(eslint@10.5.0)
+      '@typescript-eslint/parser': 8.61.0(eslint@10.5.0)(typescript@6.0.3)
 
-  eslint-plugin-yml@3.3.1(eslint@10.1.0):
+  eslint-plugin-yml@3.4.0(eslint@10.5.0):
     dependencies:
       '@eslint/core': 1.1.1
-      '@eslint/plugin-kit': 0.6.1
+      '@eslint/plugin-kit': 0.7.2
       '@ota-meshi/ast-token-store': 0.3.0
-      debug: 4.4.3
       diff-sequences: 29.6.3
       escape-string-regexp: 5.0.0
-      eslint: 10.1.0
+      eslint: 10.5.0
       natural-compare: 1.4.0
       yaml-eslint-parser: 2.0.0
-    transitivePeerDependencies:
-      - supports-color
 
-  eslint-processor-vue-blocks@2.0.0(@vue/compiler-sfc@3.5.31)(eslint@10.1.0):
+  eslint-processor-vue-blocks@2.0.0(@vue/compiler-sfc@3.5.38)(eslint@10.5.0):
     dependencies:
-      '@vue/compiler-sfc': 3.5.31
-      eslint: 10.1.0
-
-  eslint-scope@8.4.0:
-    dependencies:
-      esrecurse: 4.3.0
-      estraverse: 5.3.0
+      '@vue/compiler-sfc': 3.5.38
+      eslint: 10.5.0
 
   eslint-scope@9.1.2:
     dependencies:
@@ -3968,14 +4148,14 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.1.0:
+  eslint@10.5.0:
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@10.1.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0)
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.23.3
-      '@eslint/config-helpers': 0.5.3
-      '@eslint/core': 1.1.1
-      '@eslint/plugin-kit': 0.6.1
+      '@eslint/config-array': 0.23.5
+      '@eslint/config-helpers': 0.6.0
+      '@eslint/core': 1.2.1
+      '@eslint/plugin-kit': 0.7.2
       '@humanfs/node': 0.16.6
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.2
@@ -4005,8 +4185,8 @@ snapshots:
 
   espree@10.4.0:
     dependencies:
-      acorn: 8.15.0
-      acorn-jsx: 5.3.2(acorn@8.15.0)
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
       eslint-visitor-keys: 4.2.1
 
   espree@11.2.0:
@@ -4014,10 +4194,6 @@ snapshots:
       acorn: 8.16.0
       acorn-jsx: 5.3.2(acorn@8.16.0)
       eslint-visitor-keys: 5.0.1
-
-  esquery@1.6.0:
-    dependencies:
-      estraverse: 5.3.0
 
   esquery@1.7.0:
     dependencies:
@@ -4057,8 +4233,18 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
   fast-uri@3.1.0:
     optional: true
+
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
 
   fault@2.0.1:
     dependencies:
@@ -4220,9 +4406,9 @@ snapshots:
 
   globals@15.15.0: {}
 
-  globals@16.4.0: {}
-
   globals@17.4.0: {}
+
+  globals@17.6.0: {}
 
   globrex@0.1.2: {}
 
@@ -4230,14 +4416,15 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  happy-dom@20.8.8:
+  happy-dom@20.10.4:
     dependencies:
       '@types/node': 25.5.0
       '@types/whatwg-mimetype': 3.0.2
       '@types/ws': 8.18.1
+      buffer-image-size: 0.6.4
       entities: 7.0.1
       whatwg-mimetype: 3.0.0
-      ws: 8.20.0
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -4372,6 +4559,8 @@ snapshots:
 
   jsdoc-type-pratt-parser@7.1.1: {}
 
+  jsdoc-type-pratt-parser@7.2.0: {}
+
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
@@ -4385,9 +4574,9 @@ snapshots:
 
   jsonc-eslint-parser@3.1.0:
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.16.0
       eslint-visitor-keys: 5.0.1
-      semver: 7.7.2
+      semver: 7.7.4
 
   jsonfile@6.1.0:
     dependencies:
@@ -4395,6 +4584,10 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
     optional: true
+
+  katex@0.16.47:
+    dependencies:
+      commander: 8.3.0
 
   keyv@4.5.4:
     dependencies:
@@ -4609,6 +4802,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-math@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      longest-streak: 3.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+      unist-util-remove-position: 5.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   mdast-util-phrasing@4.1.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -4712,6 +4917,16 @@ snapshots:
       micromark-extension-gfm-tagfilter: 2.0.0
       micromark-extension-gfm-task-list-item: 2.1.0
       micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.1
+
+  micromark-extension-math@3.1.0:
+    dependencies:
+      '@types/katex': 0.16.8
+      devlop: 1.1.0
+      katex: 0.16.47
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.1
 
   micromark-factory-destination@2.0.1:
@@ -4861,18 +5076,18 @@ snapshots:
 
   mlly@1.7.4:
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.16.0
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.5.4
 
-  module-replacements@2.11.0: {}
+  module-replacements@3.0.0-beta.8: {}
 
   ms@2.1.3: {}
 
   muggle-string@0.4.1: {}
 
-  nanoid@3.3.11: {}
+  nanoid@3.3.12: {}
 
   natural-compare@1.4.0: {}
 
@@ -4961,16 +5176,14 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@4.0.3: {}
-
   picomatch@4.0.4: {}
 
-  pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)):
+  pinia@3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3)):
     dependencies:
       '@vue/devtools-api': 7.7.9
-      vue: 3.5.31(typescript@6.0.2)
+      vue: 3.5.38(typescript@6.0.3)
     optionalDependencies:
-      typescript: 6.0.2
+      typescript: 6.0.3
 
   pkg-types@1.3.1:
     dependencies:
@@ -4995,9 +5208,9 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss@8.5.8:
+  postcss@8.5.15:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -5009,7 +5222,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  qs@6.14.0:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 
@@ -5027,11 +5240,11 @@ snapshots:
 
   refa@0.12.1:
     dependencies:
-      '@eslint-community/regexpp': 4.12.1
+      '@eslint-community/regexpp': 4.12.2
 
   regexp-ast-analysis@0.7.1:
     dependencies:
-      '@eslint-community/regexpp': 4.12.1
+      '@eslint-community/regexpp': 4.12.2
       refa: 0.12.1
 
   regexp-tree@0.1.27: {}
@@ -5063,32 +5276,32 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rolldown@1.0.0-rc.12:
+  rolldown@1.0.3:
     dependencies:
-      '@oxc-project/types': 0.122.0
-      '@rolldown/pluginutils': 1.0.0-rc.12
+      '@oxc-project/types': 0.133.0
+      '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.12
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.12
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.12
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.12
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.12
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.12
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.12
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.12
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.12
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.12
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.12
+      '@rolldown/binding-android-arm64': 1.0.3
+      '@rolldown/binding-darwin-arm64': 1.0.3
+      '@rolldown/binding-darwin-x64': 1.0.3
+      '@rolldown/binding-freebsd-x64': 1.0.3
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.3
+      '@rolldown/binding-linux-arm64-gnu': 1.0.3
+      '@rolldown/binding-linux-arm64-musl': 1.0.3
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.3
+      '@rolldown/binding-linux-s390x-gnu': 1.0.3
+      '@rolldown/binding-linux-x64-gnu': 1.0.3
+      '@rolldown/binding-linux-x64-musl': 1.0.3
+      '@rolldown/binding-openharmony-arm64': 1.0.3
+      '@rolldown/binding-wasm32-wasi': 1.0.3
+      '@rolldown/binding-win32-arm64-msvc': 1.0.3
+      '@rolldown/binding-win32-x64-msvc': 1.0.3
 
   safe-buffer@5.1.2: {}
 
   scslre@0.3.0:
     dependencies:
-      '@eslint-community/regexpp': 4.12.1
+      '@eslint-community/regexpp': 4.12.2
       refa: 0.12.1
       regexp-ast-analysis: 0.7.1
 
@@ -5096,10 +5309,6 @@ snapshots:
     dependencies:
       lru-cache: 6.0.0
     optional: true
-
-  semver@7.7.1: {}
-
-  semver@7.7.2: {}
 
   semver@7.7.4: {}
 
@@ -5240,11 +5449,14 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@1.0.1: {}
-
   tinyexec@1.0.4: {}
 
   tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
@@ -5275,14 +5487,15 @@ snapshots:
     dependencies:
       eslint-visitor-keys: 5.0.1
 
-  ts-api-utils@2.5.0(typescript@6.0.2):
+  ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
-      typescript: 6.0.2
+      typescript: 6.0.3
 
-  ts-declaration-location@1.0.7(typescript@6.0.2):
+  ts-declaration-location@1.0.7(typescript@6.0.3):
     dependencies:
-      picomatch: 4.0.3
-      typescript: 6.0.2
+      picomatch: 4.0.4
+      typescript: 6.0.3
+    optional: true
 
   tslib@2.8.1:
     optional: true
@@ -5294,7 +5507,7 @@ snapshots:
   typescript@5.8.2:
     optional: true
 
-  typescript@6.0.2: {}
+  typescript@6.0.3: {}
 
   ufo@1.5.4: {}
 
@@ -5302,9 +5515,16 @@ snapshots:
 
   undici-types@7.18.2: {}
 
+  undici-types@7.24.6: {}
+
   unist-util-is@6.0.0:
     dependencies:
       '@types/unist': 3.0.3
+
+  unist-util-remove-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-visit: 5.0.0
 
   unist-util-stringify-position@4.0.0:
     dependencies:
@@ -5324,7 +5544,7 @@ snapshots:
   universalify@2.0.1:
     optional: true
 
-  unplugin-dts@1.0.0-beta.6(@microsoft/api-extractor@7.57.7(@types/node@25.5.0))(@vue/language-core@3.2.6)(typescript@6.0.2)(vite@8.0.3(@types/node@25.5.0)(yaml@2.8.3)):
+  unplugin-dts@1.0.2(@microsoft/api-extractor@7.57.7(@types/node@25.9.3))(@vue/language-core@3.3.5)(rolldown@1.0.3)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(yaml@2.8.3)):
     dependencies:
       '@rollup/pluginutils': 5.3.0
       '@volar/typescript': 2.4.28
@@ -5333,12 +5553,13 @@ snapshots:
       kolorist: 1.8.0
       local-pkg: 1.1.2
       magic-string: 0.30.21
-      typescript: 6.0.2
+      typescript: 6.0.3
       unplugin: 2.3.11
     optionalDependencies:
-      '@microsoft/api-extractor': 7.57.7(@types/node@25.5.0)
-      '@vue/language-core': 3.2.6
-      vite: 8.0.3(@types/node@25.5.0)(yaml@2.8.3)
+      '@microsoft/api-extractor': 7.57.7(@types/node@25.9.3)
+      '@vue/language-core': 3.3.5
+      rolldown: 1.0.3
+      vite: 8.0.16(@types/node@25.9.3)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -5346,7 +5567,7 @@ snapshots:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       acorn: 8.16.0
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
   update-browserslist-db@1.2.3(browserslist@4.28.1):
@@ -5367,85 +5588,85 @@ snapshots:
       clone-stats: 0.0.1
       replace-ext: 0.0.1
 
-  vite@8.0.3(@types/node@25.5.0)(yaml@2.8.3):
+  vite@8.0.16(@types/node@25.9.3)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.8
-      rolldown: 1.0.0-rc.12
-      tinyglobby: 0.2.15
+      postcss: 8.5.15
+      rolldown: 1.0.3
+      tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 25.5.0
+      '@types/node': 25.9.3
       fsevents: 2.3.3
       yaml: 2.8.3
 
-  vitest-fetch-mock@0.4.5(vitest@4.1.1(@types/node@25.5.0)(happy-dom@20.8.8)(vite@8.0.3(@types/node@25.5.0)(yaml@2.8.3))):
+  vitest-fetch-mock@0.4.5(vitest@4.1.9(@types/node@25.9.3)(happy-dom@20.10.4)(vite@8.0.16(@types/node@25.9.3)(yaml@2.8.3))):
     dependencies:
-      vitest: 4.1.1(@types/node@25.5.0)(happy-dom@20.8.8)(vite@8.0.3(@types/node@25.5.0)(yaml@2.8.3))
+      vitest: 4.1.9(@types/node@25.9.3)(happy-dom@20.10.4)(vite@8.0.16(@types/node@25.9.3)(yaml@2.8.3))
 
-  vitest@4.1.1(@types/node@25.5.0)(happy-dom@20.8.8)(vite@8.0.3(@types/node@25.5.0)(yaml@2.8.3)):
+  vitest@4.1.9(@types/node@25.9.3)(happy-dom@20.10.4)(vite@8.0.16(@types/node@25.9.3)(yaml@2.8.3)):
     dependencies:
-      '@vitest/expect': 4.1.1
-      '@vitest/mocker': 4.1.1(vite@8.0.3(@types/node@25.5.0)(yaml@2.8.3))
-      '@vitest/pretty-format': 4.1.1
-      '@vitest/runner': 4.1.1
-      '@vitest/snapshot': 4.1.1
-      '@vitest/spy': 4.1.1
-      '@vitest/utils': 4.1.1
+      '@vitest/expect': 4.1.9
+      '@vitest/mocker': 4.1.9(vite@8.0.16(@types/node@25.9.3)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/runner': 4.1.9
+      '@vitest/snapshot': 4.1.9
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
       es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.3(@types/node@25.5.0)(yaml@2.8.3)
+      vite: 8.0.16(@types/node@25.9.3)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 25.5.0
-      happy-dom: 20.8.8
+      '@types/node': 25.9.3
+      happy-dom: 20.10.4
     transitivePeerDependencies:
       - msw
 
   vscode-uri@3.0.8: {}
 
-  vue-component-type-helpers@2.1.10: {}
+  vue-component-type-helpers@3.3.5: {}
 
-  vue-eslint-parser@10.4.0(eslint@10.1.0):
+  vue-eslint-parser@10.4.0(eslint@10.5.0):
     dependencies:
       debug: 4.4.3
-      eslint: 10.1.0
-      eslint-scope: 8.4.0
-      eslint-visitor-keys: 4.2.1
-      espree: 10.4.0
-      esquery: 1.6.0
-      semver: 7.7.2
+      eslint: 10.5.0
+      eslint-scope: 9.1.2
+      eslint-visitor-keys: 5.0.1
+      espree: 11.2.0
+      esquery: 1.7.0
+      semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
 
-  vue-tsc@3.2.6(typescript@6.0.2):
+  vue-tsc@3.3.5(typescript@6.0.3):
     dependencies:
       '@volar/typescript': 2.4.28
-      '@vue/language-core': 3.2.6
-      typescript: 6.0.2
+      '@vue/language-core': 3.3.5
+      typescript: 6.0.3
 
-  vue@3.5.31(typescript@6.0.2):
+  vue@3.5.38(typescript@6.0.3):
     dependencies:
-      '@vue/compiler-dom': 3.5.31
-      '@vue/compiler-sfc': 3.5.31
-      '@vue/runtime-dom': 3.5.31
-      '@vue/server-renderer': 3.5.31(vue@3.5.31(typescript@6.0.2))
-      '@vue/shared': 3.5.31
+      '@vue/compiler-dom': 3.5.38
+      '@vue/compiler-sfc': 3.5.38
+      '@vue/runtime-dom': 3.5.38
+      '@vue/server-renderer': 3.5.38(vue@3.5.38(typescript@6.0.3))
+      '@vue/shared': 3.5.38
     optionalDependencies:
-      typescript: 6.0.2
+      typescript: 6.0.3
 
   web-streams-polyfill@3.3.3: {}
 
-  web-streams-polyfill@4.2.0: {}
+  web-streams-polyfill@4.3.0: {}
 
   webpack-virtual-modules@0.6.2: {}
 
@@ -5480,7 +5701,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.20.0: {}
+  ws@8.21.0: {}
 
   xml-name-validator@4.0.0: {}
 
@@ -5492,9 +5713,7 @@ snapshots:
   yaml-eslint-parser@2.0.0:
     dependencies:
       eslint-visitor-keys: 5.0.1
-      yaml: 2.8.1
-
-  yaml@2.8.1: {}
+      yaml: 2.8.3
 
   yaml@2.8.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+minimumReleaseAgeExclude:
+  - '@volverjs/data@2.0.5'
+  - happy-dom@20.10.4
+
+onlyBuiltDependencies:
+  - esbuild

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,45 @@
+# @volverjs/query-vue — Claude Code skills
+
+This repository ships an installable [Claude Code](https://docs.claude.com/en/docs/claude-code)
+plugin that helps agents integrate `@volverjs/query-vue` into a Vue 3 application.
+
+## Available skills
+
+| Skill | Invoke | What it does |
+| ----- | ------ | ------------ |
+| [`volverjs-query-vue`](./volverjs-query-vue/SKILL.md) | `/volverjs-query-vue:volverjs-query-vue` (auto-loads on relevant requests) | Guides store scaffolding with `defineStoreRepository`, the `read` → `submit` → `remove` actions and their options (autoExecute, group, directory, executeWhen, persistence, keepAlive…), the `ReadProvider`/`SubmitProvider`/`RemoveProvider` components, the caching/normalized-item-cache model, error handling, cleanup and best practices. |
+
+## Install
+
+The repo is its own plugin marketplace. From Claude Code:
+
+```text
+/plugin marketplace add volverjs/query-vue
+/plugin install volverjs-query-vue@volverjs-query-vue
+```
+
+The skill then loads automatically when you ask things like "fetch products in my
+Vue app with @volverjs/query-vue" or "wire up a store repository with read and submit".
+
+## Manual install (without the plugin manager)
+
+Copy the skill into your project or user skills directory:
+
+```bash
+# project-local
+cp -r skills/volverjs-query-vue .claude/skills/volverjs-query-vue
+# or user-wide
+cp -r skills/volverjs-query-vue ~/.claude/skills/volverjs-query-vue
+```
+
+## Layout
+
+```text
+.claude-plugin/
+  plugin.json        # plugin manifest
+  marketplace.json   # marketplace catalog (the repo hosts itself)
+skills/
+  volverjs-query-vue/
+    SKILL.md         # the skill
+    references/      # store-setup, read, submit, remove
+```

--- a/skills/volverjs-query-vue/SKILL.md
+++ b/skills/volverjs-query-vue/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: volverjs-query-vue
+description: >-
+  Build Vue 3 data-fetching and mutation logic with the @volverjs/query-vue
+  library (a Pinia store built on the repository pattern with caching, a
+  normalized item cache, and query tracking). Use this skill whenever the user
+  works with @volverjs/query-vue or mentions defineStoreRepository, a "store
+  repository", or the read()/submit()/remove() composable actions, or the
+  ReadProvider/SubmitProvider/RemoveProvider components — and also when they ask
+  to fetch/create/update/delete data in Vue through a @volverjs/data Repository
+  or RepositoryHttp wired into Pinia, even if they don't name the library
+  explicitly. Covers store scaffolding, the three actions and their options
+  (autoExecute, group, directory, executeWhen, persistence, keepAlive…), the
+  provider components, and caching/error-handling best practices.
+---
+
+# @volverjs/query-vue
+
+`@volverjs/query-vue` turns a [`@volverjs/data`](https://github.com/volverjs/data)
+repository into a Pinia store with **query tracking**, **request caching**, and a
+**normalized item cache**. It is conceptually close to TanStack Query, but built
+around the repository pattern and Pinia.
+
+You help users wire up a store and write correct, idiomatic code that uses it.
+Read the relevant `references/*.md` file before writing non-trivial code for an
+action — they hold the full option lists and patterns, and this main file stays
+deliberately short so it loads fast.
+
+## When this applies
+
+- Setting up a store with `defineStoreRepository()`.
+- Reading, creating/updating, or deleting data via `read()`, `submit()`, `remove()`.
+- Using `ReadProvider` / `SubmitProvider` / `RemoveProvider` in templates.
+- Reasoning about caching, persistence, the item cache, error handling, or cleanup.
+
+Default stack for examples: **Vue 3 SFC + `<script setup lang="ts">` + Pinia +
+`RepositoryHttp`**. Adapt if the user is on JS or a different `@volverjs/data` repository.
+
+## Mental model (read this first)
+
+Four concepts explain almost every behavior. Keep them straight and the API is predictable:
+
+- **Query** — a single, named tracked request returned by an action (`read`/`submit`/`remove`).
+  Its reactive `data`, `isLoading`, `isError`, etc. are what your component renders. If you
+  don't pass a `name`, one is generated, so each call is independent.
+- **Hash** — a cache entry keyed by a hash of the request parameters. Two reads with the same
+  params share a hash (and its cached result). This is what makes caching and request
+  de-duplication work.
+- **Item** — the *normalized entity cache*. On success, every returned item is stored keyed by
+  its `keyProperty` (default `'id'`). `getItemByKey` / `getItemsByKeys` read from here, so an
+  entity fetched by one query is instantly available to another.
+- **Persistence** — a hash's time-to-live (default 1 hour). Within the window, a `read()` for the
+  same params returns the cached result without refetching (unless you force it).
+
+`cleanUp()` runs automatically on idle and removes disabled queries, orphaned hashes, and items
+no longer referenced by any hash, so the store stays bounded.
+
+## Install
+
+```bash
+pnpm add @volverjs/query-vue @volverjs/data pinia vue
+```
+
+`@volverjs/data`, `pinia`, and `vue` are peer dependencies. Pinia must be
+[installed in the app](https://pinia.vuejs.org/getting-started.html) before any store is used.
+
+## Quick start — define a store
+
+A store is a composable created once (usually in its own file) and reused across components.
+See `references/store-setup.md` for every store option (`keyProperty`, `defaultPersistence`,
+`defaultParameters`, `cleanUpEvery`, …) and custom-key strategies.
+
+```ts
+// stores/users.ts
+import { HttpClient, RepositoryHttp } from '@volverjs/data'
+import { defineStoreRepository } from '@volverjs/query-vue'
+
+export type User = { id?: number, username: string }
+
+const httpClient = new HttpClient({ prefixUrl: 'https://my-domain.com' })
+// ':id?' is an optional path segment; other params become query string
+const usersRepository = new RepositoryHttp<User>(httpClient, 'users/:id?')
+
+export const useUsersStore = defineStoreRepository(usersRepository, 'users')
+```
+
+In a component, call the composable to get actions, getters, state, and provider components:
+
+```ts
+const {
+    read, submit, remove,                       // actions
+    getItemByKey, getItemsByKeys, getQueryByName, // getters
+    ReadProvider, SubmitProvider, RemoveProvider, // components
+    cleanUp, resetQuery,
+    queries, items, hashes,                       // reactive state (Maps)
+} = useUsersStore()
+```
+
+## The three actions
+
+Each action returns reactive refs you bind directly in the template. Full option lists, return
+shapes, and patterns live in the reference files — open the one you need:
+
+- **`read(params?, options?)`** → `references/read.md`. GET-style fetching with caching,
+  `autoExecute` on reactive params, `executeWhen`/`resetWhen` gating, `group` (infinite scroll),
+  and `directory` (list mode). Returns `{ data, item, isLoading, isError, isSuccess, error, errors, metadata, query, status, execute, reset, stop, cleanup, ignoreUpdates }`.
+- **`submit(payload, params?, options?)`** → `references/submit.md`. Create (POST) or update (PUT),
+  auto-inferred from whether the payload carries a `keyProperty`, or forced with `action`.
+  Two-way payload sync (great with `v-model`). Returns the same shape as `read` plus the synced payload.
+- **`remove(params?, options?)`** → `references/remove.md`. DELETE; evicts matching items from the
+  cache on success. Executes immediately by default.
+
+Minimal read example:
+
+```vue
+<script setup lang="ts">
+import { useUsersStore } from '@/stores/users'
+
+const { read } = useUsersStore()
+const { data, isLoading, isError } = read() // GET /users
+</script>
+
+<template>
+  <p v-if="isLoading">Loading…</p>
+  <p v-else-if="isError">Something went wrong 😭</p>
+  <ul v-else>
+    <li v-for="user in data" :key="user.id">{{ user.username }}</li>
+  </ul>
+</template>
+```
+
+## Provider components
+
+Providers expose an action's reactive result through a scoped slot — handy when you'd otherwise
+lift state or prop-drill. They accept `params` and `options` props; `SubmitProvider` also takes a
+`v-model` for the payload. Detailed prop/slot tables are in each action's reference file.
+
+Important default: **`ReadProvider` runs immediately, but `SubmitProvider` and `RemoveProvider`
+do not** (their default `options` set `immediate: false`) — you trigger them via the slot's
+`execute()`.
+
+```vue
+<template>
+  <ReadProvider v-slot="{ isLoading, isError, data }" :params="{ active: true }">
+    <p v-if="isLoading">Loading…</p>
+    <ul v-else-if="!isError">
+      <li v-for="user in data" :key="user.id">{{ user.username }}</li>
+    </ul>
+  </ReadProvider>
+</template>
+```
+
+## Best practices & gotchas
+
+- **`keyProperty` is required in responses.** A non-`directory` `read()` and every `submit()`
+  expect each returned item to carry the key (default `'id'`); otherwise the query goes to
+  `error`. Use `directory: true` for lists of keyless rows, or set a custom `keyProperty` at
+  store creation (see `references/store-setup.md`).
+- **Don't destructure away reactivity in templates.** The returned `data`, `isLoading`, … are
+  refs/computeds — keep them as refs and let the template unwrap them. (Pinia `state` like
+  `items`/`queries` is already unwrapped to the underlying `Map`.)
+- **Caching is by params hash + persistence.** Re-reading the same params within the persistence
+  window won't refetch. Force a network call with `execute(true)`; bypass caching with
+  `persistence: 0`.
+- **Prefer `isLoading`/`isSuccess`/`status` over inspecting `data`** to detect state. `data` is
+  always an array (empty when there's nothing), so `data.length === 0` is "empty", not "not loaded".
+- **Error handling.** `RepositoryHttp` (via `ky`) rejects on non-2xx; the action catches it and
+  sets `isError`/`error`/`errors`. Render from those refs.
+- **Cleanup & `keepAlive`.** On unmount an action's query is disabled and eventually cleaned up.
+  Pass `keepAlive: true` to keep a query (and its cache) alive across unmounts — useful for data
+  shared between routes. Disable the idle cleanup entirely with `cleanUpEvery: 0` (or `false`).
+- **`autoExecute` is debounced.** It re-runs on reactive `params`/`payload` changes;
+  `defaultDebounce` (store) or `autoExecuteDebounce` (per call) controls the delay (default `0`).
+- **One store per resource, created once.** Reusing the same store `name` across modules returns
+  the same Pinia store instance — intentional for sharing, a footgun if accidental.
+
+## Reference files
+
+- `references/store-setup.md` — `defineStoreRepository`, all store options, custom `keyProperty`,
+  repository setup, getters (`getItemByKey`, `getItemsByKeys`, `getQueryByName`), `resetQuery`/`cleanUp`.
+- `references/read.md` — `read()` options, return values, caching, `autoExecute`, `executeWhen`,
+  `resetWhen`, `group`, `directory`, `ReadProvider`.
+- `references/submit.md` — `submit()` create vs update, `action` override, payload sync /
+  `disablePayloadSync`, arrays, `SubmitProvider` with `v-model`.
+- `references/remove.md` — `remove()` options, item eviction, `RemoveProvider`.

--- a/skills/volverjs-query-vue/references/read.md
+++ b/skills/volverjs-query-vue/references/read.md
@@ -1,0 +1,184 @@
+# read()
+
+`read(params?, options?)` fetches data (GET-style) with caching, query tracking, and the
+normalized item cache. By default it executes immediately.
+
+```ts
+const result = read(params, options)
+```
+
+- `params` — a params map **or a `Ref` to one**. Passing a ref enables reactive patterns
+  (`autoExecute`, `executeWhen`). Merged with the store's `defaultParameters`.
+
+## Return value
+
+All fields are reactive (`computed`/`ref`) — bind them directly; don't read `.value` in templates.
+
+```ts
+const {
+  data,        // TResponse[] — always an array (empty when nothing)
+  item,        // TResponse | undefined — data[0], convenient for single-record reads
+  isLoading,   // boolean
+  isSuccess,   // boolean
+  isError,     // boolean
+  error,       // Error | undefined — first error
+  errors,      // Error[]
+  metadata,    // ParamMap | undefined — repository-provided metadata (pagination, etc.)
+  status,      // StoreRepositoryStatus: 'idle' | 'loading' | 'success' | 'error'
+  query,        // the tracked query object
+
+  execute,     // (newParamsOrForce?, newRepositoryOptionsOrForce?) => Promise<...>
+  reset,       // () => void — reset this query
+  stop,        // () => void — stop autoExecute watchers
+  cleanup,     // () => void — disable the query (called automatically on unmount)
+  ignoreUpdates, // (cb) => void — run cb without triggering autoExecute watchers
+} = read(params, options)
+```
+
+### `execute()`
+
+Re-run the query. Flexible signature:
+
+```ts
+execute()                          // re-run with current params (served from cache if fresh)
+execute(true)                      // force a network call, ignoring the cache
+execute({ id: 2 })                 // run with new params
+execute({ id: 2 }, { signal })     // new params + per-call repositoryOptions
+```
+
+The first argument is either new params or a boolean "force"; the second is either
+repositoryOptions or a boolean "force".
+
+## Options
+
+```ts
+read(params, {
+  /* Name the query so you can address it via getQueryByName/resetQuery. Default: generated. */
+  name: undefined,
+
+  /*
+   * Accumulate results from every read() under this query instead of replacing them.
+   * Use for infinite scroll / "load more": each page's items are appended to `data`.
+   */
+  group: false,
+
+  /*
+   * Directory mode: store the response as a standalone list on the query and DON'T normalize
+   * items into the shared item cache. Use for keyless rows or lists you don't want to dedupe.
+   * In directory mode the key-property validation is skipped.
+   */
+  directory: false,
+
+  /* Keep the query (and its cache) alive when the component unmounts. Default false. */
+  keepAlive: false,
+
+  /* Execute as soon as read() is called. Default true. */
+  immediate: true,
+
+  /* Cache TTL (ms) for this query's hash. 0 disables caching. Default: store defaultPersistence. */
+  persistence: 60 * 60 * 1000,
+
+  /*
+   * Gate execution. A reactive boolean ref OR a predicate over params.
+   * The action only runs when this is truthy.
+   *   executeWhen: computed(() => params.value.id !== undefined)
+   *   executeWhen: (p) => p?.id !== undefined
+   */
+  executeWhen: undefined,
+
+  /*
+   * Reset the query when this becomes true. A boolean ref OR a predicate over (newParams, oldParams).
+   *   resetWhen: (newP, oldP) => newP.id !== oldP?.id
+   */
+  resetWhen: undefined,
+
+  /* Re-run automatically when reactive `params` change (requires a ref params). Debounced. */
+  autoExecute: false,
+
+  /* Debounce (ms) for autoExecute. Default: store defaultDebounce (0). */
+  autoExecuteDebounce: 0,
+
+  /* Re-run on window focus / document becoming visible. Default false. */
+  autoExecuteOnWindowFocus: false,
+  autoExecuteOnDocumentVisibility: false,
+
+  /* Passed straight to the repository read method (headers, signal, ...). */
+  repositoryOptions: undefined,
+})
+```
+
+## Patterns
+
+### Single record by id
+
+```ts
+const { item, isLoading } = read({ id: route.params.id })
+// item is data[0]; render it directly
+```
+
+### Reactive params + autoExecute (refetch on change)
+
+```ts
+const params = ref({ id: '1' })
+const { data, isLoading } = read(params, { autoExecute: true })
+// later: params.value.id = '2'  -> refetches automatically (debounced)
+```
+
+### Gate until ready with `executeWhen`
+
+```ts
+const params = ref<{ id?: string }>({ id: undefined })
+const { item } = read(params, {
+  autoExecute: true,
+  executeWhen: p => p?.id !== undefined, // skips the request until id is set
+})
+```
+
+### Infinite scroll with `group`
+
+```ts
+const params = ref({ page: 1, limit: 20 })
+const { data, isLoading } = read(params, { group: true, autoExecute: true })
+function loadMore() { params.value.page++ } // appends the next page to `data`
+```
+
+### Force refresh / bypass cache
+
+```ts
+const { data, execute } = read({ active: true })
+function refresh() { execute(true) }        // ignore the persistence window
+// or read({ active: true }, { persistence: 0 }) to never cache
+```
+
+### Reading from the normalized cache elsewhere
+
+Once any read has loaded an entity, other components can grab it without a request:
+
+```ts
+const { getItemByKey } = useUsersStore()
+const user = getItemByKey(selectedId) // selectedId can be a ref
+```
+
+## ReadProvider
+
+A component that runs `read()` and exposes the result through a scoped slot — useful instead of
+lifting state. It **executes immediately** (unlike Submit/Remove providers).
+
+Props:
+- `params` — the params map.
+- `options` — a `read()` options object.
+
+The default slot receives the same fields `read()` returns (`isLoading`, `isError`, `data`,
+`item`, `error`, `execute`, `reset`, …).
+
+```vue
+<template>
+  <ReadProvider v-slot="{ isLoading, isError, data, error }" :params="{ active: true }">
+    <p v-if="isLoading">Loading…</p>
+    <p v-else-if="isError">{{ error?.message }}</p>
+    <ul v-else>
+      <li v-for="user in data" :key="user.id">{{ user.username }}</li>
+    </ul>
+  </ReadProvider>
+</template>
+```

--- a/skills/volverjs-query-vue/references/remove.md
+++ b/skills/volverjs-query-vue/references/remove.md
@@ -1,0 +1,118 @@
+# remove()
+
+`remove(params?, options?)` deletes data (DELETE) and, on success, evicts the matching items from
+the normalized cache by their key. Unlike `read`/`submit`, its API is intentionally smaller (no
+`autoExecute`, no `executeWhen`).
+
+```ts
+const result = remove(params, options)
+```
+
+- `params` — params map (or ref) identifying what to delete. Merged with `defaultParameters`.
+  The key param (e.g. `id`) determines which cached items are evicted; it may be a single value
+  or an array.
+
+## Return value
+
+```ts
+const {
+  isLoading, isSuccess, isError,
+  error,      // Error | undefined
+  errors,     // Error[]
+  status,     // 'idle' | 'loading' | 'success' | 'error'
+  query,
+  execute,    // (newParams?, newRepositoryOptions?) => Promise<...>
+  cleanup,    // () => void
+} = remove(params, options)
+```
+
+Note: `remove()` does not expose `data`/`item` (a delete has no entity to return).
+
+## Options
+
+```ts
+remove(params, {
+  /* Name the query. Default: generated. */
+  name: undefined,
+
+  /* Keep the query alive across unmount. Default false. */
+  keepAlive: false,
+
+  /* Execute immediately when remove() is called. Default true. */
+  immediate: true,
+
+  /* Passed straight to the repository remove method. */
+  repositoryOptions: undefined,
+})
+```
+
+## Patterns
+
+### Delete immediately
+
+```ts
+const { remove } = useUsersStore()
+const { isSuccess } = remove({ id: 1 }) // DELETE /users/1; item 1 leaves the cache on success
+```
+
+### Delete on demand (button handler)
+
+```ts
+const { remove } = useUsersStore()
+const { execute, isLoading } = remove({ id: 1 }, { immediate: false })
+// in template: <button :disabled="isLoading" @click="execute()">Delete</button>
+```
+
+### Delete a different record later
+
+```ts
+const { execute } = remove(undefined, { immediate: false })
+function deleteUser(id: number) { execute({ id }) }
+```
+
+## RemoveProvider
+
+A component that runs `remove()` via a scoped slot. It does **not** execute immediately (default
+`options.immediate` is `false`) — call the slot's `execute()`.
+
+Props:
+- `params` — params map.
+- `options` — a `remove()` options object.
+
+The slot receives `isLoading`, `isError`, `isSuccess`, `error`, `errors`, `status`, `query`,
+`execute`, `cleanup`.
+
+```vue
+<script setup lang="ts">
+import { useUsersStore } from '@/stores/users'
+
+const { RemoveProvider } = useUsersStore()
+</script>
+
+<template>
+  <RemoveProvider v-slot="{ execute, isLoading }" :params="{ id: 1 }">
+    <button :disabled="isLoading" @click="execute()">Delete user</button>
+  </RemoveProvider>
+</template>
+```
+
+### Common composition: read then remove
+
+A typical UI reads a record and, once available, lets the user delete it. Nest a
+`RemoveProvider` inside a `ReadProvider`:
+
+```vue
+<template>
+  <ReadProvider v-slot="{ item, isLoading }" :params="{ id: 1 }">
+    <p v-if="isLoading">Loading…</p>
+    <RemoveProvider
+      v-else-if="item"
+      v-slot="{ execute }"
+      :params="{ id: item.id }"
+    >
+      <span>{{ item.username }}</span>
+      <button @click="execute()">Delete</button>
+    </RemoveProvider>
+  </ReadProvider>
+</template>
+```

--- a/skills/volverjs-query-vue/references/store-setup.md
+++ b/skills/volverjs-query-vue/references/store-setup.md
@@ -1,0 +1,122 @@
+# Store setup
+
+`defineStoreRepository(repository, name, options?)` creates a Pinia store composable from a
+`@volverjs/data` repository. Call it once per resource (typically in its own module) and import
+the returned composable wherever you need it.
+
+```ts
+function defineStoreRepository<TRequest, TResponse = TRequest>(
+  repository: Repository<TRequest, TResponse> | RepositoryHttp<TRequest, TResponse>,
+  name: string,
+  options?: StoreRepositoryOptions<TResponse>,
+): /* a Pinia store definition */
+```
+
+- `TRequest` is the shape you send; `TResponse` defaults to `TRequest` and is the shape you read
+  back. Use two type params when request and response differ (e.g. a create DTO vs. the stored entity).
+- `name` is the Pinia store id. **Reusing the same `name` returns the same store instance** — great
+  for sharing data, a bug if accidental.
+
+## Repository
+
+Any `@volverjs/data` repository works; `RepositoryHttp` is the common one.
+
+```ts
+import { HttpClient, RepositoryHttp } from '@volverjs/data'
+
+const httpClient = new HttpClient({ prefixUrl: 'https://my-domain.com' })
+
+// The template maps params to the URL. `:id?` is an optional path segment;
+// any param not consumed by the template is appended as a query-string value.
+const usersRepository = new RepositoryHttp<User>(httpClient, 'users/:id?')
+// read({ id: 1 })            -> GET   /users/1
+// read({ active: true })     -> GET   /users?active=true
+// read({ id: 1, lang: 'en' }) -> GET  /users/1?lang=en
+```
+
+Per-action `repositoryOptions` are passed straight through to the repository method (headers,
+signal, etc.), so you rarely need to touch the repository after creation.
+
+## Store options
+
+All optional. Defaults shown.
+
+```ts
+export const useUsersStore = defineStoreRepository(usersRepository, 'users', {
+  /*
+   * How to uniquely identify an item. Drives the normalized item cache and the
+   * key-property validation on responses. Default: 'id'.
+   * Three forms:
+   *   keyProperty: 'uuid'                                   // a key of the item
+   *   keyProperty: item => item.uuid                        // a getter function
+   *   keyProperty: { name: 'uuid', get: item => item.uuid } // named getter (best for fn-based keys)
+   */
+  keyProperty: 'id',
+
+  /* Default cache TTL (ms) for every query. Override per read() with `persistence`. Default 1h. */
+  defaultPersistence: 60 * 60 * 1000,
+
+  /* Default debounce (ms) for autoExecute. Override per action with `autoExecuteDebounce`. Default 0. */
+  defaultDebounce: 0,
+
+  /* Params merged into every request. Default {}. */
+  defaultParameters: {},
+
+  /* Hash function for request params. Default Hash.cyrb53 from @volverjs/data. */
+  hashFunction: undefined,
+
+  /*
+   * Idle interval (ms) for the automatic store clean up.
+   * Pass 0 or false to disable it entirely. Default 3000.
+   */
+  cleanUpEvery: 3 * 1000,
+})
+```
+
+### Choosing a `keyProperty`
+
+- Prefer the simple string form (`'id'`, `'uuid'`) — it's used both to read the key and (for the
+  object/string forms) to know which param name carries the key during `submit`/`remove`.
+- The bare function form (`item => item.uuid`) can read the key but has no name, so internally the
+  param name falls back to `'id'`. If your key field isn't `id`, use the **named** object form
+  `{ name: 'uuid', get: item => item.uuid }` so submit/remove target the right param.
+
+## What the composable returns
+
+```ts
+const store = useUsersStore()
+```
+
+**Actions** (see the per-action references):
+- `read(params?, options?)`
+- `submit(payload, params?, options?)`
+- `remove(params?, options?)`
+
+**Getters** (all return reactive `computed`s, so use them in templates / watchers):
+- `getItemByKey(key)` — one item from the normalized cache. `key` may be a ref.
+  ```ts
+  const selectedId = ref(1)
+  const user = getItemByKey(selectedId) // recomputes when selectedId changes
+  ```
+- `getItemsByKeys(keys)` — array of items for the given keys (missing keys are skipped). `keys`
+  may be a ref to an array.
+- `getQueryByName(name)` — the tracked query object for a named query, or `undefined`.
+
+**State** (Pinia state, already unwrapped to plain reactive `Map`s — no `.value`):
+- `items` — `Map<key, TResponse>`, the normalized cache.
+- `queries` — `Map<name, query>`.
+- `hashes` — `Map<hashKey, hash>`.
+
+**Maintenance:**
+- `resetQuery(name)` — clears a named query's results (and triggers a cleanup). Items only
+  referenced by that query are evicted.
+- `cleanUp()` — manually run the cleanup that otherwise fires on idle: drop disabled queries,
+  orphaned hashes, and items no longer referenced by any hash.
+
+**Provider components:** `ReadProvider`, `SubmitProvider`, `RemoveProvider` (see per-action references).
+
+## Naming queries
+
+Pass `name` in an action's options to address a query later with `getQueryByName(name)` or
+`resetQuery(name)`. Without a name, each action call gets a fresh random name and is fully
+independent — so two un-named `submit()`s in the same tick won't clobber each other.

--- a/skills/volverjs-query-vue/references/submit.md
+++ b/skills/volverjs-query-vue/references/submit.md
@@ -1,0 +1,174 @@
+# submit()
+
+`submit(payload, params?, options?)` creates (POST) or updates (PUT) data. Whether it's a create
+or an update is **inferred from the payload's key property**, or you can force it with `action`.
+
+```ts
+const result = submit(payload, params, options)
+```
+
+- `payload` — the item, an array of items, or a **`Ref`** to either. A ref enables `autoExecute`
+  and two-way sync.
+- `params` — params map (or ref). Merged with the store's `defaultParameters`. If the payload
+  carries a key and the params don't already include it, the key is added to params automatically
+  (so the URL targets the right record on update).
+
+## Create vs. update
+
+- **No key on the payload → create (POST).** `submit({ username: 'ada' })`
+- **Key present on the payload → update (PUT).** `submit({ id: 1, username: 'ada' })`
+- For an array payload: update if *every* item has a key, otherwise create.
+- Override explicitly with `action: 'create' | 'update'` (only those two are valid).
+
+## Return value
+
+Same reactive shape as `read()`:
+
+```ts
+const {
+  data,        // TResponse[] — the server response (always an array)
+  item,        // TResponse | undefined — data[0]
+  isLoading, isSuccess, isError,
+  error, errors,
+  metadata,
+  status,
+  query,
+  execute,     // (newData?, newParams?, newRepositoryOptions?) => Promise<...>
+  stop, cleanup, ignoreUpdates,
+} = submit(payload, params, options)
+```
+
+### `execute()`
+
+```ts
+execute()                              // submit the current payload/params
+execute({ username: 'grace' })         // submit new data
+execute(newData, { team: 'x' })        // new data + params
+execute(newData, params, { signal })   // + per-call repositoryOptions
+```
+
+## Payload sync (two-way)
+
+When `payload` is a ref, on success the server response is written back into it (so server-assigned
+fields like `id` or timestamps appear in your local object). This is what makes `v-model` on
+`SubmitProvider` work. Disable it with `disablePayloadSync: true`.
+
+```ts
+const draft = ref<User>({ username: 'ada' })
+const { isSuccess } = submit(draft)
+// after success: draft.value.id is populated from the response
+```
+
+The write-back is wrapped so it does **not** retrigger an `autoExecute` submit.
+
+## Options
+
+```ts
+submit(payload, params, {
+  /* Name the query. Default: generated (each call is independent). */
+  name: undefined,
+
+  /* Keep the query alive across unmount. Default false. */
+  keepAlive: false,
+
+  /* Submit as soon as submit() is called. Default true. */
+  immediate: true,
+
+  /*
+   * Gate execution: a boolean ref OR a predicate over (payload, params).
+   *   executeWhen: (p) => !!p?.username
+   */
+  executeWhen: undefined,
+
+  /* Re-submit automatically when reactive payload/params change (debounced). Default false. */
+  autoExecute: false,
+  autoExecuteDebounce: 0, // default: store defaultDebounce
+
+  /* Re-submit on window focus / visibility. Default false. */
+  autoExecuteOnWindowFocus: false,
+  autoExecuteOnDocumentVisibility: false,
+
+  /* Don't write the response back into a ref payload. Default false. */
+  disablePayloadSync: false,
+
+  /*
+   * Force the operation instead of inferring it from the key.
+   * Only 'create' or 'update' are valid (the enum members or the strings).
+   */
+  action: undefined,
+
+  /* Passed straight to the repository create/update method. */
+  repositoryOptions: undefined,
+})
+```
+
+The response must contain the `keyProperty` for each item, or the query goes to `error`.
+
+## Patterns
+
+### Create from a form, then read the assigned id
+
+```ts
+const draft = ref<User>({ username: '' })
+const { submit } = useUsersStore()
+const { isLoading, isSuccess, execute } = submit(draft, undefined, { immediate: false })
+function onSubmit() { execute() } // POST; draft.value.id is filled on success
+```
+
+### Update an existing record
+
+```ts
+const user = ref<User>({ id: 1, username: 'ada' })
+submit(user) // PUT /users/1 (key inferred -> update)
+```
+
+### Auto-save on change
+
+```ts
+const user = ref<User>({ id: 1, username: 'ada' })
+submit(user, undefined, { autoExecute: true, autoExecuteDebounce: 500 })
+// edits to user.value are persisted ~500ms after the last change
+```
+
+### Force a create even though the payload has an id
+
+```ts
+submit({ id: 1, username: 'ada' }, undefined, { action: 'create' }) // POST, not PUT
+```
+
+### Submit many at once
+
+```ts
+submit([{ username: 'a' }, { username: 'b' }]) // create (no keys) -> POST with an array body
+```
+
+## SubmitProvider
+
+A component that runs `submit()` via a scoped slot, with `v-model` for the payload.
+It does **not** execute immediately (default `options.immediate` is `false`) — trigger it with the
+slot's `execute()`.
+
+Props:
+- `v-model` (`modelValue`) — the payload; kept in sync with the server response.
+- `params` — params map.
+- `options` — a `submit()` options object.
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useUsersStore } from '@/stores/users'
+
+const { SubmitProvider } = useUsersStore()
+const form = ref({ username: '' })
+</script>
+
+<template>
+  <SubmitProvider v-slot="{ isLoading, error, execute }" v-model="form">
+    <form @submit.prevent="execute()">
+      <input v-model="form.username" name="username">
+      <p v-if="error">{{ error.message }}</p>
+      <button type="submit" :disabled="isLoading">Save</button>
+    </form>
+  </SubmitProvider>
+</template>
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -383,13 +383,9 @@ export function defineStoreRepository<TRequest, TResponse = TRequest>(repository
                     )
                     if (keys.length) {
                         data.push(
-                            ...keys.reduce((acc: TResponse[], key) => {
-                                const item = storeItems.value.get(key)
-                                if (item) {
-                                    acc.push(item)
-                                }
-                                return acc
-                            }, []),
+                            ...keys
+                                .map(key => storeItems.value.get(key))
+                                .filter(item => item !== undefined),
                         )
                     }
                     return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,6 @@ import type {
     StoreRepositoryQuery,
     StoreRepositoryReadOptions,
     StoreRepositoryRemoveOptions,
-    StoreRepositorySubmitAction,
     StoreRepositorySubmitOptions,
 } from './types'
 import { Hash } from '@volverjs/data/hash'
@@ -21,7 +20,6 @@ import {
     isRef,
     markRaw,
     onBeforeUnmount,
-
     ref,
     toRefs,
     unref,
@@ -262,9 +260,9 @@ export function defineStoreRepository<TRequest, TResponse = TRequest>(repository
         const _cleanUpItems = () => {
             // collect every key still referenced by a living hash
             const referencedKeys = new Set<unknown>()
-            storeHashes.value.forEach((hash) => {
+            for (const hash of storeHashes.value.values()) {
                 hash.keys?.forEach(key => referencedKeys.add(key))
-            })
+            }
             // drop items that are no longer referenced to avoid unbounded growth
             storeItems.value.forEach((_item, key) => {
                 if (!referencedKeys.has(key)) {
@@ -1151,7 +1149,7 @@ export function defineStoreRepository<TRequest, TResponse = TRequest>(repository
 export {
     StoreRepositoryAction,
     StoreRepositoryStatus,
-}
+} from './constants'
 
 export type {
     ParamMap,
@@ -1162,4 +1160,4 @@ export type {
     StoreRepositoryRemoveOptions,
     StoreRepositorySubmitAction,
     StoreRepositorySubmitOptions,
-}
+} from './types'

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import type {
     StoreRepositoryQuery,
     StoreRepositoryReadOptions,
     StoreRepositoryRemoveOptions,
+    StoreRepositorySubmitAction,
     StoreRepositorySubmitOptions,
 } from './types'
 import { Hash } from '@volverjs/data/hash'
@@ -258,12 +259,27 @@ export function defineStoreRepository<TRequest, TResponse = TRequest>(repository
             })
         }
 
+        const _cleanUpItems = () => {
+            // collect every key still referenced by a living hash
+            const referencedKeys = new Set<unknown>()
+            storeHashes.value.forEach((hash) => {
+                hash.keys?.forEach(key => referencedKeys.add(key))
+            })
+            // drop items that are no longer referenced to avoid unbounded growth
+            storeItems.value.forEach((_item, key) => {
+                if (!referencedKeys.has(key)) {
+                    storeItems.value.delete(key)
+                }
+            })
+        }
+
         const cleanUp = () => {
             _cleanUpQueries()
             _cleanUpHashes()
+            _cleanUpItems()
         }
 
-        if (cleanUpEvery !== undefined) {
+        if (cleanUpEvery) {
             const { idle } = useIdle(cleanUpEvery)
             watch(idle, (isIdle) => {
                 if (isIdle) {
@@ -278,8 +294,9 @@ export function defineStoreRepository<TRequest, TResponse = TRequest>(repository
         const getItemsByKeys = (keys: AnyKey[] | Ref<AnyKey[]>) =>
             computed(() => {
                 return unref(keys).reduce((acc: TResponse[], key) => {
-                    if (storeItems.value.get(key)) {
-                        acc.push(storeItems.value.get(key) as TResponse)
+                    const item = storeItems.value.get(key)
+                    if (item) {
+                        acc.push(item)
                     }
                     return acc
                 }, [])
@@ -359,8 +376,9 @@ export function defineStoreRepository<TRequest, TResponse = TRequest>(repository
                     if (keys.length) {
                         data.push(
                             ...keys.reduce((acc: TResponse[], key) => {
-                                if (storeItems.value.get(key)) {
-                                    acc.push(storeItems.value.get(key) as TResponse)
+                                const item = storeItems.value.get(key)
+                                if (item) {
+                                    acc.push(item)
                                 }
                                 return acc
                             }, []),
@@ -412,7 +430,7 @@ export function defineStoreRepository<TRequest, TResponse = TRequest>(repository
                 Parameters<typeof repository.read>[1]
             > = {},
         ) => {
-            const queryName = options?.name ?? getRandomValues(1).toString()
+            const queryName = options?.name ?? getRandomValues().toString()
             const storeQuery = getQueryByName(queryName)
             const executeReturn = (aborted = false) => ({
                 query: storeQuery.value,
@@ -667,7 +685,7 @@ export function defineStoreRepository<TRequest, TResponse = TRequest>(repository
                 Parameters<typeof repository.create>[2]
             > = {},
         ) => {
-            const queryName = options?.name ?? Date.now().toString()
+            const queryName = options?.name ?? getRandomValues().toString()
             const storeQuery = getQueryByName(queryName)
 
             const executeReturn = (aborted = false) => ({
@@ -839,7 +857,7 @@ export function defineStoreRepository<TRequest, TResponse = TRequest>(repository
                 isSuccess: computed(() => storeQuery.value?.isSuccess ?? false),
                 errors: computed(() => storeQuery.value?.errors ?? []),
                 error: computed(() => storeQuery.value?.errors?.[0]),
-                data: computed(() => storeQuery.value?.data),
+                data: computed(() => storeQuery.value?.data ?? []),
                 item: computed(() => storeQuery.value?.data?.[0]),
                 metadata: computed(() => storeQuery.value?.metadata),
                 execute,
@@ -914,18 +932,19 @@ export function defineStoreRepository<TRequest, TResponse = TRequest>(repository
             params?: Ref<ParamMap> | ParamMap,
             {
                 name,
+                keepAlive,
                 immediate = true,
                 repositoryOptions,
             }: StoreRepositoryRemoveOptions<
                 Parameters<typeof repository.remove>[1]
             > = {},
         ) => {
-            const queryName = name ?? getRandomValues(1).toString()
+            const queryName = name ?? getRandomValues().toString()
             const storeQuery = getQueryByName(queryName)
             const executeReturn = (aborted = false) => ({
                 query: storeQuery.value,
                 metadata: storeQuery.value?.metadata,
-                errors: storeQuery.value?.errors,
+                errors: storeQuery.value?.errors ?? [],
                 error: storeQuery.value?.errors?.[0],
                 isSuccess: storeQuery.value?.isSuccess ?? false,
                 isError: storeQuery.value?.isError ?? false,
@@ -1003,7 +1022,9 @@ export function defineStoreRepository<TRequest, TResponse = TRequest>(repository
             }
             // cleanup
             const cleanup = () => {
-                _disableQuery(queryName)
+                if (!keepAlive) {
+                    _disableQuery(queryName)
+                }
             }
             tryOnUnmounted(() => {
                 cleanup()
@@ -1139,5 +1160,6 @@ export type {
     StoreRepositoryQuery,
     StoreRepositoryReadOptions,
     StoreRepositoryRemoveOptions,
+    StoreRepositorySubmitAction,
     StoreRepositorySubmitOptions,
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -207,7 +207,7 @@ export function defineStoreRepository<TRequest, TResponse = TRequest>(repository
                                 ...storeQuery.storeHashes,
                                 hashKey,
                             ]),
-                        } as StoreRepositoryQuery)
+                        })
                         return
                     }
                     if (!storeQuery.storeHashes.has(hashKey)) {
@@ -224,7 +224,7 @@ export function defineStoreRepository<TRequest, TResponse = TRequest>(repository
                 storeQueries.value.set(queryName, {
                     enabled: true,
                     storeHashes: new Set([hashKey]),
-                } as StoreRepositoryQuery)
+                })
             }
         }
 
@@ -234,7 +234,7 @@ export function defineStoreRepository<TRequest, TResponse = TRequest>(repository
                 storeQueries.value.set(name, {
                     ...query,
                     enabled: false,
-                } as StoreRepositoryQuery)
+                })
             }
         }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -316,7 +316,17 @@ export function defineStoreRepository<TRequest, TResponse = TRequest>(repository
                         isLoading,
                         isSuccess,
                         errors,
-                    } = [...query.storeHashes].reduce(
+                    } = [...query.storeHashes].reduce<{
+                        keys: unknown[]
+                        data: TResponse[]
+                        metadata: ParamMap
+                        params: ParamMap
+                        timestamp: number
+                        isLoading: boolean
+                        isError: boolean
+                        isSuccess: boolean
+                        errors: Error[]
+                    }>(
                         (acc, item) => {
                             if (storeHashes.value.has(item)) {
                                 const {
@@ -360,15 +370,15 @@ export function defineStoreRepository<TRequest, TResponse = TRequest>(repository
                             return acc
                         },
                         {
-                            keys: [] as unknown[],
-                            data: [] as TResponse[],
-                            metadata: {} as ParamMap,
-                            params: {} as ParamMap,
+                            keys: [],
+                            data: [],
+                            metadata: {},
+                            params: {},
                             timestamp: 0,
                             isLoading: false,
                             isError: false,
                             isSuccess: false,
-                            errors: [] as Error[],
+                            errors: [],
                         },
                     )
                     if (keys.length) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,7 +14,11 @@ export type StoreRepositoryOptions<T> = {
     defaultDebounce?: number | Ref<number>
     defaultParameters?: ParamMap
     hashFunction?: (str: string) => number
-    cleanUpEvery?: number
+    /**
+     * Interval (in ms) used to schedule the store clean up on idle.
+     * Pass `0` or `false` to disable the automatic clean up.
+     */
+    cleanUpEvery?: number | false
 }
 
 export type StoreRepositoryHash<T = unknown> = {
@@ -57,6 +61,13 @@ export type StoreRepositoryReadOptions<
     repositoryOptions?: Ref<RepositoryReadOptions> | RepositoryReadOptions
 }
 
+/**
+ * The actions `submit()` can perform. `read` and `remove` are intentionally
+ * excluded: a submit always maps to a `create` (POST) or an `update` (PUT).
+ */
+type SubmitActionEnum = StoreRepositoryAction.create | StoreRepositoryAction.update
+export type StoreRepositorySubmitAction = SubmitActionEnum | `${SubmitActionEnum}`
+
 export type StoreRepositorySubmitOptions<
     T,
     RepositorySubmitOptions = Record<string, unknown>,
@@ -72,7 +83,7 @@ export type StoreRepositorySubmitOptions<
     autoExecuteOnWindowFocus?: boolean
     autoExecuteOnDocumentVisibility?: boolean
     disablePayloadSync?: boolean
-    action?: Ref<StoreRepositoryAction | `${StoreRepositoryAction}`> | StoreRepositoryAction | `${StoreRepositoryAction}`
+    action?: Ref<StoreRepositorySubmitAction> | StoreRepositorySubmitAction
     repositoryOptions?: Ref<RepositorySubmitOptions> | RepositorySubmitOptions
 }
 
@@ -80,6 +91,7 @@ export type StoreRepositoryRemoveOptions<
     RepositoryRemoveOptions = Record<string, unknown>,
 > = {
     name?: string
+    keepAlive?: boolean
     immediate?: boolean
     repositoryOptions?: Ref<RepositoryRemoveOptions> | RepositoryRemoveOptions
 }

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -24,9 +24,11 @@ import {
 import { StoreRepositoryStatus } from './constants'
 
 export function clone<T>(value: T): T {
+    if (value === undefined || value === null) {
+        return value
+    }
     if (
         typeof value === 'object'
-        && value !== null
         && 'clone' in value
         && typeof value.clone === 'function'
     ) {
@@ -88,13 +90,13 @@ export function initAutoExecuteReadHandlers<TResponse>(
         immediate = true,
         executeWhen = () => true,
         autoExecute = false,
-        autoExecuteDebounce = 500,
+        autoExecuteDebounce = 0,
         autoExecuteOnWindowFocus = false,
         autoExecuteOnDocumentVisibility = false,
     } = options
     let ignoreUpdates: IgnoredUpdater | undefined
     let stopHandler: WatchStopHandle | undefined
-    let executeOnFocunsStopHandler: WatchStopHandle | undefined
+    let executeOnFocusStopHandler: WatchStopHandle | undefined
     let documentVisibilityStopHandler: WatchStopHandle | undefined
     const normalizedParams = isRef(params)
         ? (params as Ref<ParamMap>)
@@ -145,7 +147,7 @@ export function initAutoExecuteReadHandlers<TResponse>(
     // execute on window focus
     if (autoExecuteOnWindowFocus) {
         const focused = useWindowFocus()
-        executeOnFocunsStopHandler = watch(focused, (isFocused) => {
+        executeOnFocusStopHandler = watch(focused, (isFocused) => {
             if (isFocused && normalizedExecuteWhen.value) {
                 execute()
             }
@@ -162,7 +164,7 @@ export function initAutoExecuteReadHandlers<TResponse>(
     }
     const stop = () => {
         stopHandler?.()
-        executeOnFocunsStopHandler?.()
+        executeOnFocusStopHandler?.()
         documentVisibilityStopHandler?.()
     }
     return { stop, ignoreUpdates }
@@ -204,13 +206,13 @@ export function initAutoExecuteSubmitHandlers<TRequest, TResponse>(
         immediate = true,
         executeWhen = () => true,
         autoExecute = false,
-        autoExecuteDebounce = 500,
+        autoExecuteDebounce = 0,
         autoExecuteOnWindowFocus = false,
         autoExecuteOnDocumentVisibility = false,
     } = options
     let ignoreUpdates: IgnoredUpdater | undefined
     let stopHandler: WatchStopHandle | undefined
-    let executeOnFocunsStopHandler: WatchStopHandle | undefined
+    let executeOnFocusStopHandler: WatchStopHandle | undefined
     let documentVisibilityStopHandler: WatchStopHandle | undefined
     const normalizedPayload = isRef(payload) ? payload : computed(() => payload)
     const normalizedParams = isRef(params)
@@ -262,7 +264,7 @@ export function initAutoExecuteSubmitHandlers<TRequest, TResponse>(
     // execute on window focus
     if (autoExecuteOnWindowFocus) {
         const focused = useWindowFocus()
-        executeOnFocunsStopHandler = watch(focused, (isFocused) => {
+        executeOnFocusStopHandler = watch(focused, (isFocused) => {
             if (isFocused && normalizedExecuteWhen.value) {
                 resubmit()
             }
@@ -279,13 +281,13 @@ export function initAutoExecuteSubmitHandlers<TRequest, TResponse>(
     }
     const stop = () => {
         stopHandler?.()
-        executeOnFocunsStopHandler?.()
+        executeOnFocusStopHandler?.()
         documentVisibilityStopHandler?.()
     }
     return { stop, ignoreUpdates }
 }
 
-export function getRandomValues(length: number) {
-    const array = new Uint32Array(length)
+export function getRandomValues() {
+    const array = new Uint32Array(1)
     return crypto.getRandomValues(array)[0]
 }

--- a/test/error-handling.test.ts
+++ b/test/error-handling.test.ts
@@ -1,0 +1,124 @@
+import { HttpClient, RepositoryHttp } from '@volverjs/data'
+import { flushPromises } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { ref } from 'vue'
+import { defineStoreRepository } from '../src/index'
+import { fetchMock, setupStoreTest } from './utils'
+
+const httpClient = new HttpClient({
+    prefixUrl: 'https://myapi.com/v1',
+})
+type Entity = { id?: string, name?: string }
+const repositoryHttp = new RepositoryHttp<Entity>(httpClient, ':id?')
+
+describe('error handling', () => {
+    setupStoreTest()
+
+    it('read sets the error state when the request fails', async () => {
+        // 400 is not retried by ky, so a single mocked response is enough
+        fetchMock.mockResponseOnce('Bad Request', { status: 400 })
+        const useStore = defineStoreRepository<Entity>(
+            repositoryHttp,
+            'error-read',
+        )
+        const { read } = useStore()
+        const { isLoading, isError, isSuccess, error, errors } = read({
+            id: '1',
+        })
+        expect(isLoading.value).toBe(true)
+        await flushPromises()
+        expect(isLoading.value).toBe(false)
+        expect(isError.value).toBe(true)
+        expect(isSuccess.value).toBe(false)
+        expect(error.value).toBeInstanceOf(Error)
+        expect(errors.value.length).toBeGreaterThan(0)
+    })
+
+    it('read succeeds with an empty array response', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([]))
+        const useStore = defineStoreRepository<Entity>(
+            repositoryHttp,
+            'error-read-empty',
+        )
+        const { read } = useStore()
+        const { isError, isSuccess, data } = read({ id: '1' })
+        await flushPromises()
+        expect(isError.value).toBe(false)
+        expect(isSuccess.value).toBe(true)
+        expect(data.value).toEqual([])
+    })
+
+    it('read errors when the response is missing the key property', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([{ name: 'no-id' }]))
+        const useStore = defineStoreRepository<Entity>(
+            repositoryHttp,
+            'error-read-missing-key',
+        )
+        const { read } = useStore()
+        const { isError, isSuccess, error } = read({ id: '1' })
+        await flushPromises()
+        expect(isError.value).toBe(true)
+        expect(isSuccess.value).toBe(false)
+        expect(error.value?.message).toContain('id')
+    })
+
+    it('read in directory mode does not require the key property', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([{ name: 'no-id' }]))
+        const useStore = defineStoreRepository<Entity>(
+            repositoryHttp,
+            'error-read-directory-no-key',
+        )
+        const { read } = useStore()
+        const { isError, isSuccess, data } = read(
+            { id: '1' },
+            { directory: true },
+        )
+        await flushPromises()
+        expect(isError.value).toBe(false)
+        expect(isSuccess.value).toBe(true)
+        expect(data.value?.[0]?.name).toBe('no-id')
+    })
+
+    it('submit sets the error state when the request fails', async () => {
+        fetchMock.mockResponseOnce('Bad Request', { status: 400 })
+        const useStore = defineStoreRepository<Entity>(
+            repositoryHttp,
+            'error-submit',
+        )
+        const { submit } = useStore()
+        const { isError, isSuccess, error } = submit({ name: 'test' })
+        await flushPromises()
+        expect(isError.value).toBe(true)
+        expect(isSuccess.value).toBe(false)
+        expect(error.value).toBeInstanceOf(Error)
+    })
+
+    it('submit does not throw on an empty array response (clone of undefined)', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([]))
+        const useStore = defineStoreRepository<Entity>(
+            repositoryHttp,
+            'error-submit-empty',
+        )
+        const { submit } = useStore()
+        const payload = ref<Entity>({ name: 'test' })
+        const { isError, isSuccess } = submit(payload)
+        await flushPromises()
+        // before the clone(undefined) guard this flipped to an error state
+        expect(isError.value).toBe(false)
+        expect(isSuccess.value).toBe(true)
+    })
+
+    it('remove sets the error state when the request fails', async () => {
+        fetchMock.mockResponseOnce('Bad Request', { status: 400 })
+        const useStore = defineStoreRepository<Entity>(
+            repositoryHttp,
+            'error-remove',
+        )
+        const { remove } = useStore()
+        const { isError, isSuccess, error } = remove({ id: '1' })
+        await flushPromises()
+        expect(isError.value).toBe(true)
+        expect(isSuccess.value).toBe(false)
+        expect(error.value).toBeInstanceOf(Error)
+    })
+})

--- a/test/read-advanced.test.ts
+++ b/test/read-advanced.test.ts
@@ -1,0 +1,77 @@
+import { HttpClient, RepositoryHttp } from '@volverjs/data'
+import { flushPromises } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { ref } from 'vue'
+import { defineStoreRepository } from '../src/index'
+import { fetchMock, setupStoreTest } from './utils'
+
+const httpClient = new HttpClient({
+    prefixUrl: 'https://myapi.com/v1',
+})
+type Entity = { id: string }
+const repositoryHttp = new RepositoryHttp<Entity>(httpClient, ':id?')
+
+describe('read advanced', () => {
+    setupStoreTest()
+
+    it('disables the query on cleanup by default', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: '1' }]))
+        const useStore = defineStoreRepository<Entity>(
+            repositoryHttp,
+            'read-cleanup-default',
+        )
+        const { read, getQueryByName } = useStore()
+        const { cleanup } = read({ id: '1' }, { name: 'q' })
+        await flushPromises()
+        expect(getQueryByName('q').value?.enabled).toBe(true)
+        cleanup()
+        expect(getQueryByName('q').value?.enabled).toBe(false)
+    })
+
+    it('keeps the query alive on cleanup when keepAlive is true', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: '1' }]))
+        const useStore = defineStoreRepository<Entity>(
+            repositoryHttp,
+            'read-keepalive',
+        )
+        const { read, getQueryByName } = useStore()
+        const { cleanup } = read({ id: '1' }, { name: 'q', keepAlive: true })
+        await flushPromises()
+        expect(getQueryByName('q').value?.enabled).toBe(true)
+        cleanup()
+        expect(getQueryByName('q').value?.enabled).toBe(true)
+    })
+
+    it('getItemByKey reacts to a ref key', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: '1' }, { id: '2' }]))
+        const useStore = defineStoreRepository<Entity>(
+            repositoryHttp,
+            'read-reactive-key',
+        )
+        const { read, getItemByKey } = useStore()
+        read({})
+        await flushPromises()
+        const key = ref('1')
+        const item = getItemByKey(key)
+        expect(item.value?.id).toBe('1')
+        key.value = '2'
+        expect(item.value?.id).toBe('2')
+    })
+
+    it('does not refetch a cached query within the persistence window', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: '1' }]))
+        const useStore = defineStoreRepository<Entity>(
+            repositoryHttp,
+            'read-persistence-cache',
+        )
+        const { read } = useStore()
+        const first = read({ id: '1' })
+        await flushPromises()
+        expect(first.isSuccess.value).toBe(true)
+        // a second read with the same params hits the cache, no extra request
+        const second = read({ id: '1' })
+        await flushPromises()
+        expect(second.isSuccess.value).toBe(true)
+        expect(fetchMock.mock.calls.length).toBe(1)
+    })
+})

--- a/test/read.test.ts
+++ b/test/read.test.ts
@@ -1,13 +1,11 @@
-import { createTestingPinia } from '@pinia/testing'
 import { HttpClient, RepositoryHttp } from '@volverjs/data'
-import { flushPromises, mount } from '@vue/test-utils'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import createFetchMock from 'vitest-fetch-mock'
+import { flushPromises } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
 import { computed, nextTick, ref } from 'vue'
 import { defineStoreRepository } from '../src/index'
 import ReadProvider from './components/ReadProvider.vue'
+import { fetchMock, mountWithPinia, setupStoreTest } from './utils'
 
-const fetchMock = createFetchMock(vi)
 const httpClient = new HttpClient({
     prefixUrl: 'https://myapi.com/v1',
 })
@@ -15,31 +13,11 @@ type Entity = { id: string }
 const repositoryHttp = new RepositoryHttp<Entity>(httpClient, ':id?')
 
 describe('read', () => {
-    // Mount app
-    mount(
-        {
-            template: '<div></div>',
-        },
-        {
-            global: {
-                plugins: [createTestingPinia({ stubActions: false })],
-            },
-        },
-    )
-
-    // Reset mocks for each test
-    beforeEach(() => {
-        fetchMock.enableMocks()
-        fetchMock.resetMocks()
-    })
+    setupStoreTest()
 
     it('read from a parameters map with component provider', async () => {
         fetchMock.mockResponseOnce(JSON.stringify([{ id: '12345' }]))
-        const wrapper = mount(ReadProvider, {
-            global: {
-                plugins: [createTestingPinia({ stubActions: false })],
-            },
-        })
+        const wrapper = mountWithPinia(ReadProvider)
         expect(wrapper.text()).toContain('Loading...')
         await flushPromises()
         await nextTick()

--- a/test/remove-advanced.test.ts
+++ b/test/remove-advanced.test.ts
@@ -1,0 +1,64 @@
+import { HttpClient, RepositoryHttp } from '@volverjs/data'
+import { flushPromises } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { defineStoreRepository } from '../src/index'
+import { fetchMock, setupStoreTest } from './utils'
+
+const httpClient = new HttpClient({
+    prefixUrl: 'https://myapi.com/v1',
+})
+type Entity = { id: string }
+const repositoryHttp = new RepositoryHttp<Entity>(httpClient, ':id?')
+
+describe('remove advanced', () => {
+    setupStoreTest()
+
+    it('disables the query on cleanup by default', async () => {
+        fetchMock.mockResponseOnce('', { status: 204 })
+        const useStore = defineStoreRepository<Entity>(
+            repositoryHttp,
+            'remove-cleanup-default',
+        )
+        const { remove, getQueryByName } = useStore()
+        const { cleanup } = remove({ id: '1' }, { name: 'rm' })
+        await flushPromises()
+        expect(getQueryByName('rm').value?.enabled).toBe(true)
+        cleanup()
+        expect(getQueryByName('rm').value?.enabled).toBe(false)
+    })
+
+    it('keeps the query alive on cleanup when keepAlive is true', async () => {
+        fetchMock.mockResponseOnce('', { status: 204 })
+        const useStore = defineStoreRepository<Entity>(
+            repositoryHttp,
+            'remove-keepalive',
+        )
+        const { remove, getQueryByName } = useStore()
+        const { cleanup } = remove({ id: '1' }, {
+            name: 'rm',
+            keepAlive: true,
+        })
+        await flushPromises()
+        expect(getQueryByName('rm').value?.enabled).toBe(true)
+        cleanup()
+        expect(getQueryByName('rm').value?.enabled).toBe(true)
+    })
+
+    it('does not execute when immediate is false', async () => {
+        fetchMock.mockResponseOnce('', { status: 204 })
+        const useStore = defineStoreRepository<Entity>(
+            repositoryHttp,
+            'remove-not-immediate',
+        )
+        const { remove } = useStore()
+        const { isLoading, execute } = remove({ id: '1' }, {
+            immediate: false,
+        })
+        expect(isLoading.value).toBe(false)
+        expect(fetchMock.mock.calls.length).toBe(0)
+        await execute()
+        expect(fetchMock.mock.calls.length).toBe(1)
+        const request = fetchMock.mock.calls[0][0] as Request
+        expect(request.method).toBe('DELETE')
+    })
+})

--- a/test/remove.test.ts
+++ b/test/remove.test.ts
@@ -1,13 +1,11 @@
-import { createTestingPinia } from '@pinia/testing'
 import { HttpClient, RepositoryHttp } from '@volverjs/data'
-import { flushPromises, mount } from '@vue/test-utils'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import createFetchMock from 'vitest-fetch-mock'
+import { flushPromises } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
 import { nextTick } from 'vue'
 import { defineStoreRepository } from '../src/index'
 import RemoveProvider from './components/RemoveProvider.vue'
+import { fetchMock, mountWithPinia, setupStoreTest } from './utils'
 
-const fetchMock = createFetchMock(vi)
 const httpClient = new HttpClient({
     prefixUrl: 'https://myapi.com/v1',
 })
@@ -15,31 +13,11 @@ type Entity = { id: string }
 const repositoryHttp = new RepositoryHttp<Entity>(httpClient, ':id?')
 
 describe('remove', () => {
-    // Mount app
-    mount(
-        {
-            template: '<div></div>',
-        },
-        {
-            global: {
-                plugins: [createTestingPinia({ stubActions: false })],
-            },
-        },
-    )
-
-    // Reset mocks for each test
-    beforeEach(() => {
-        fetchMock.enableMocks()
-        fetchMock.resetMocks()
-    })
+    setupStoreTest()
 
     it('remove from a parameters map with component provider', async () => {
         fetchMock.mockResponseOnce(JSON.stringify([{ id: '12345' }]))
-        const wrapper = mount(RemoveProvider, {
-            global: {
-                plugins: [createTestingPinia({ stubActions: false })],
-            },
-        })
+        const wrapper = mountWithPinia(RemoveProvider)
         expect(wrapper.find('div[data-test="loading"]').exists()).toBe(true)
         await flushPromises()
         await nextTick()

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -1,0 +1,153 @@
+import { HttpClient, RepositoryHttp } from '@volverjs/data'
+import { Hash } from '@volverjs/data/hash'
+import { flushPromises } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { defineStoreRepository } from '../src/index'
+import { fetchMock, setupStoreTest } from './utils'
+
+const httpClient = new HttpClient({
+    prefixUrl: 'https://myapi.com/v1',
+})
+type Entity = { id: string }
+const repositoryHttp = new RepositoryHttp<Entity>(httpClient, ':id?')
+
+describe('store', () => {
+    setupStoreTest()
+
+    it('getQueryByName returns undefined for an unknown query', () => {
+        const useStore = defineStoreRepository<Entity>(
+            repositoryHttp,
+            'store-unknown-query',
+        )
+        const { getQueryByName } = useStore()
+        expect(getQueryByName('does-not-exist').value).toBeUndefined()
+    })
+
+    it('getItemsByKeys returns every cached item matching the keys', async () => {
+        fetchMock.mockResponseOnce(
+            JSON.stringify([{ id: '1' }, { id: '2' }, { id: '3' }]),
+        )
+        const useStore = defineStoreRepository<Entity>(
+            repositoryHttp,
+            'store-items-by-keys',
+        )
+        const { read, getItemsByKeys } = useStore()
+        read({})
+        await flushPromises()
+        const items = getItemsByKeys(['1', '3', 'missing'])
+        expect(items.value.map(item => item.id)).toEqual(['1', '3'])
+    })
+
+    it('resetQuery clears the query data and evicts unreferenced items', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: '12345' }]))
+        const useStore = defineStoreRepository<Entity>(
+            repositoryHttp,
+            'store-reset-query',
+        )
+        const { read, getItemByKey, getQueryByName, resetQuery } = useStore()
+        read({ id: '12345' }, { name: 'my-query' })
+        await flushPromises()
+        expect(getItemByKey('12345').value?.id).toBe('12345')
+        expect(getQueryByName('my-query').value?.data?.[0]?.id).toBe('12345')
+
+        resetQuery('my-query')
+        // the query is emptied
+        expect(getQueryByName('my-query').value?.data).toEqual([])
+        // and the item is evicted because no living hash references it anymore
+        expect(getItemByKey('12345').value).toBeUndefined()
+    })
+
+    it('cleanUp removes disabled queries, their hashes and orphan items', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: '12345' }]))
+        const useStore = defineStoreRepository<Entity>(
+            repositoryHttp,
+            'store-cleanup',
+        )
+        const { read, getItemByKey, hashes, queries, cleanUp } = useStore()
+        const handle = read({ id: '12345' }, { name: 'to-clean' })
+        await flushPromises()
+        expect(getItemByKey('12345').value?.id).toBe('12345')
+        // `queries`/`hashes` are pinia state, already unwrapped to the Map
+        expect(queries.has('to-clean')).toBe(true)
+
+        // disable the query, then run the clean up
+        handle.cleanup()
+        cleanUp()
+
+        expect(queries.has('to-clean')).toBe(false)
+        expect(hashes.size).toBe(0)
+        expect(getItemByKey('12345').value).toBeUndefined()
+    })
+
+    it('uses a custom keyProperty function to index items', async () => {
+        type UuidEntity = { uuid: string }
+        fetchMock.mockResponseOnce(JSON.stringify([{ uuid: 'abc' }]))
+        const repo = new RepositoryHttp<UuidEntity>(httpClient, ':uuid?')
+        const useStore = defineStoreRepository<UuidEntity>(
+            repo,
+            'store-keyproperty-fn',
+            { keyProperty: entity => entity.uuid },
+        )
+        const { read, getItemByKey } = useStore()
+        read({ uuid: 'abc' })
+        await flushPromises()
+        expect(getItemByKey('abc').value?.uuid).toBe('abc')
+    })
+
+    it('uses a custom keyProperty object { name, get }', async () => {
+        type UuidEntity = { uuid: string }
+        fetchMock.mockResponseOnce(JSON.stringify([{ uuid: 'xyz' }]))
+        const repo = new RepositoryHttp<UuidEntity>(httpClient, ':uuid?')
+        const useStore = defineStoreRepository<UuidEntity>(
+            repo,
+            'store-keyproperty-object',
+            { keyProperty: { name: 'uuid', get: entity => entity.uuid } },
+        )
+        const { read, getItemByKey } = useStore()
+        read({ uuid: 'xyz' })
+        await flushPromises()
+        expect(getItemByKey('xyz').value?.uuid).toBe('xyz')
+    })
+
+    it('merges defaultParameters into every request', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: '1' }]))
+        const useStore = defineStoreRepository<Entity>(
+            repositoryHttp,
+            'store-default-parameters',
+            { defaultParameters: { lang: 'en' } },
+        )
+        const { read } = useStore()
+        read({ id: '1' })
+        await flushPromises()
+        const request = fetchMock.mock.calls[0][0] as Request
+        expect(request.url).toContain('lang=en')
+    })
+
+    it('uses the provided hashFunction', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: '1' }]))
+        const hashFunction = vi.fn((str: string) => Hash.cyrb53(str))
+        const useStore = defineStoreRepository<Entity>(
+            repositoryHttp,
+            'store-hash-function',
+            { hashFunction },
+        )
+        const { read } = useStore()
+        read({ id: '1' })
+        await flushPromises()
+        expect(hashFunction).toHaveBeenCalled()
+    })
+
+    it('accepts cleanUpEvery: false (auto clean up disabled)', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: '1' }]))
+        const useStore = defineStoreRepository<Entity>(
+            repositoryHttp,
+            'store-cleanup-disabled',
+            { cleanUpEvery: false },
+        )
+        const { read, getItemByKey } = useStore()
+        const { isSuccess } = read({ id: '1' })
+        await flushPromises()
+        expect(isSuccess.value).toBe(true)
+        expect(getItemByKey('1').value?.id).toBe('1')
+    })
+})

--- a/test/submit-advanced.test.ts
+++ b/test/submit-advanced.test.ts
@@ -1,0 +1,119 @@
+import { HttpClient, RepositoryHttp } from '@volverjs/data'
+import { flushPromises } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { ref } from 'vue'
+import { defineStoreRepository } from '../src/index'
+import { fetchMock, setupStoreTest } from './utils'
+
+const httpClient = new HttpClient({
+    prefixUrl: 'https://myapi.com/v1',
+})
+type Entity = { id?: string, name: string }
+const repositoryHttp = new RepositoryHttp<Entity>(httpClient, ':id?')
+
+describe('submit advanced', () => {
+    setupStoreTest()
+
+    it('two anonymous submits keep independent state (no queryName collision)', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: '1', name: 'a' }]))
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: '2', name: 'b' }]))
+        const useStore = defineStoreRepository<Entity>(
+            repositoryHttp,
+            'submit-independent',
+        )
+        const { submit } = useStore()
+        // both are created in the same tick with distinct params (distinct
+        // hashes): with Date.now() based names they would share the same query
+        // and clobber each other
+        const first = submit({ name: 'a' }, { tag: 'first' })
+        const second = submit({ name: 'b' }, { tag: 'second' })
+        await flushPromises()
+        expect(first.item.value?.id).toBe('1')
+        expect(second.item.value?.id).toBe('2')
+        expect(first.query.value).not.toBe(second.query.value)
+    })
+
+    it('creates many items in a single submit (array payload)', async () => {
+        fetchMock.mockResponseOnce(
+            JSON.stringify([
+                { id: '1', name: 'a' },
+                { id: '2', name: 'b' },
+            ]),
+        )
+        const useStore = defineStoreRepository<Entity>(
+            repositoryHttp,
+            'submit-array',
+        )
+        const { submit, getItemsByKeys } = useStore()
+        const { isSuccess, data } = submit([{ name: 'a' }, { name: 'b' }])
+        await flushPromises()
+        expect(isSuccess.value).toBe(true)
+        expect(data.value?.length).toBe(2)
+        expect(getItemsByKeys(['1', '2']).value.length).toBe(2)
+        const request = fetchMock.mock.calls[0][0] as Request
+        expect(request.method).toBe('POST')
+    })
+
+    it('forces an update (PUT) via the action option even without a key', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: '1', name: 'a' }]))
+        const useStore = defineStoreRepository<Entity>(
+            repositoryHttp,
+            'submit-force-update',
+        )
+        const { submit } = useStore()
+        const { isSuccess } = submit({ name: 'a' }, undefined, {
+            action: 'update',
+        })
+        await flushPromises()
+        expect(isSuccess.value).toBe(true)
+        const request = fetchMock.mock.calls[0][0] as Request
+        expect(request.method).toBe('PUT')
+    })
+
+    it('forces a create (POST) via the action option even with a key', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: '1', name: 'a' }]))
+        const useStore = defineStoreRepository<Entity>(
+            repositoryHttp,
+            'submit-force-create',
+        )
+        const { submit } = useStore()
+        const { isSuccess } = submit({ id: '1', name: 'a' }, undefined, {
+            action: 'create',
+        })
+        await flushPromises()
+        expect(isSuccess.value).toBe(true)
+        const request = fetchMock.mock.calls[0][0] as Request
+        expect(request.method).toBe('POST')
+    })
+
+    it('does not sync the payload when disablePayloadSync is true', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: '1', name: 'a' }]))
+        const useStore = defineStoreRepository<Entity>(
+            repositoryHttp,
+            'submit-disable-sync',
+        )
+        const { submit } = useStore()
+        const payload = ref<Entity>({ name: 'a' })
+        const { isSuccess } = submit(payload, undefined, {
+            disablePayloadSync: true,
+        })
+        await flushPromises()
+        expect(isSuccess.value).toBe(true)
+        // the response id is NOT written back into the payload
+        expect(payload.value.id).toBeUndefined()
+    })
+
+    it('syncs the payload back by default', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: '1', name: 'a' }]))
+        const useStore = defineStoreRepository<Entity>(
+            repositoryHttp,
+            'submit-default-sync',
+        )
+        const { submit } = useStore()
+        const payload = ref<Entity>({ name: 'a' })
+        const { isSuccess } = submit(payload)
+        await flushPromises()
+        expect(isSuccess.value).toBe(true)
+        expect(payload.value.id).toBe('1')
+    })
+})

--- a/test/submit.test.ts
+++ b/test/submit.test.ts
@@ -1,13 +1,11 @@
-import { createTestingPinia } from '@pinia/testing'
 import { HttpClient, RepositoryHttp } from '@volverjs/data'
-import { flushPromises, mount } from '@vue/test-utils'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import createFetchMock from 'vitest-fetch-mock'
+import { flushPromises } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
 import { nextTick, ref } from 'vue'
 import { defineStoreRepository } from '../src/index'
 import SubmitProvider from './components/SubmitProvider.vue'
+import { fetchMock, mountWithPinia, setupStoreTest } from './utils'
 
-const fetchMock = createFetchMock(vi)
 const httpClient = new HttpClient({
     prefixUrl: 'https://myapi.com/v1',
 })
@@ -15,23 +13,7 @@ type Entity = { id?: string, name: string }
 const repositoryHttp = new RepositoryHttp<Entity>(httpClient, ':subroute?/:id?')
 
 describe('submit', () => {
-    // Mount app
-    mount(
-        {
-            template: '<div></div>',
-        },
-        {
-            global: {
-                plugins: [createTestingPinia({ stubActions: false })],
-            },
-        },
-    )
-
-    // Reset mocks for each test
-    beforeEach(() => {
-        fetchMock.enableMocks()
-        fetchMock.resetMocks()
-    })
+    setupStoreTest()
 
     it('submit an item with POST with component provider', async () => {
         fetchMock.mockResponseOnce(
@@ -40,11 +22,7 @@ describe('submit', () => {
             ]),
             {},
         )
-        const wrapper = mount(SubmitProvider, {
-            global: {
-                plugins: [createTestingPinia({ stubActions: false })],
-            },
-        })
+        const wrapper = mountWithPinia(SubmitProvider)
         const form = wrapper.find('form')
         const firstname = wrapper.find('input[name="firstname"]')
         const lastname = wrapper.find('input[name="lastname"]')

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,0 +1,30 @@
+import type { Component } from 'vue'
+import { createTestingPinia } from '@pinia/testing'
+import { mount } from '@vue/test-utils'
+import { beforeEach, vi } from 'vitest'
+import createFetchMock from 'vitest-fetch-mock'
+
+/** Shared fetch mock for the test file that imports it. */
+export const fetchMock = createFetchMock(vi)
+
+/** Mounts a component with a fresh testing pinia instance. */
+export function mountWithPinia(component: Component) {
+    return mount(component, {
+        global: {
+            plugins: [createTestingPinia({ stubActions: false })],
+        },
+    })
+}
+
+/**
+ * Provides an active testing pinia (via a dummy mount) for direct
+ * `useStore()` calls and registers a `beforeEach` that (re)enables and
+ * resets the fetch mocks. Call it once inside a `describe` body.
+ */
+export function setupStoreTest() {
+    mountWithPinia({ template: '<div></div>' })
+    beforeEach(() => {
+        fetchMock.enableMocks()
+        fetchMock.resetMocks()
+    })
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,9 +4,11 @@
         "jsx": "preserve",
         "lib": ["ESNext", "DOM", "DOM.Iterable"],
         "useDefineForClassFields": true,
-        "baseUrl": ".",
         "module": "ESNext",
-        "moduleResolution": "Node",
+        "moduleResolution": "Bundler",
+        "paths": {
+            "@vue/shared": ["./node_modules/@vue/shared"]
+        },
         "resolveJsonModule": true,
         "types": ["vitest/globals", "vite/client"],
         "strict": true,
@@ -33,5 +35,5 @@
         "skipLibCheck": true,
         "noErrorTruncation": true
     },
-    "include": ["src/*", "test/*", "test/**/*"]
+    "include": ["vite-env.d.ts", "src/*", "test/*", "test/**/*"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { copyFileSync, existsSync } from 'node:fs'
+import { copyFileSync, existsSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 import ESLint from '@nabla/vite-plugin-eslint'
 import vue from '@vitejs/plugin-vue'
@@ -48,12 +48,28 @@ export default defineConfig({
                 rootDir: path.resolve(__dirname, 'src'),
             },
             // Manually copy types after build since unplugin-dts bug with only types export
-            afterBuild: () => {
+            afterBuild: (emittedFiles) => {
                 // copy src/types.ts to dist/types.d.ts
                 const srcTypesPath = path.resolve(__dirname, 'src/types.ts')
                 const distTypesPath = path.resolve(__dirname, 'dist/types.d.ts')
                 if (existsSync(srcTypesPath)) {
                     copyFileSync(srcTypesPath, distTypesPath)
+                }
+                // unplugin-dts emits a non-portable relative import for
+                // `@vue/shared` (e.g. `../node_modules/@vue/shared`). Rewrite it
+                // to a bare specifier so the published types resolve for
+                // consumers (it is provided transitively by the `vue` peer dep).
+                for (const [filePath, content] of emittedFiles) {
+                    if (!filePath.endsWith('.d.ts')) {
+                        continue
+                    }
+                    const rewritten = content.replace(
+                        /(['"])(?:\.\.\/)*node_modules\/@vue\/shared\1/g,
+                        '$1@vue/shared$1',
+                    )
+                    if (rewritten !== content) {
+                        writeFileSync(filePath, rewritten)
+                    }
                 }
             },
         }),


### PR DESCRIPTION
### Added

- `keepAlive` option for the `remove()` action, consistent with `read()` and `submit()`;
- `volverjs-query-vue` Claude Code plugin / agent skill (under `skills/`) that teaches AI coding agents how to use the library; installable with `/plugin marketplace add volverjs/query-vue`.

### Changed

- `submit()` `action` option is now restricted to `'create' | 'update'` (the only meaningful write operations);
- `submit().data` and the `remove()` action `errors` are now always arrays (empty instead of `undefined`), consistent with `read()`.

### Fix

- Portable type declarations: the emitted `.d.ts` referenced `@vue/shared` through a non-portable `.pnpm/…` path (TS2883), which broke type-checking for consumers; it now emits a bare `@vue/shared` specifier;
- `submit()` derived query names from `Date.now()`, so two submissions in the same millisecond could collide and overwrite each other's state; query names are now random;
- `submit()` could throw and flip to an error state on an empty response because `clone()` failed on `undefined`; `clone()` now returns `undefined`/`null` untouched;
- `cleanUpEvery` could not be disabled because of the default fallback; passing `0` or `false` now disables the automatic idle clean up;
- `cleanUp()` never evicted items from the normalized cache, so it could grow unbounded; items no longer referenced by any hash are now removed.